### PR TITLE
Static Analyzer: Adds excluded paths file.

### DIFF
--- a/tools/scan_build.supp
+++ b/tools/scan_build.supp
@@ -1,1 +1,1 @@
-/usr/include/eigen3/Eigen
+/usr/include/eigen3


### PR DESCRIPTION
> One step of [dsim-repos-index#64](https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/64)

The Static Analyzer only found one bug and it came from `Eigen`.

So, This PR adds Eigen directory(`/usr/include/eigen3/Eigen`) to the file `scan_build.supp`.

-------------------
To use the static analyzer:
```
scan-build-8 --status-bugs --use-cc=clang --use-c++=clang++ --exclude <directory1> --exclude <directory2> colcon build --packages-select <package>  --cmake-args ' -DCMAKE_LINKER=usr/bin/llvm-ld'
```
