### PR TITLE
Uses namespaces for the targets

### DIFF
--- a/src/maliput_multilane/CMakeLists.txt
+++ b/src/maliput_multilane/CMakeLists.txt
@@ -19,6 +19,13 @@ set(MALIPUT_MULTILANE_SOURCES
 
 add_library(maliput_multilane ${MALIPUT_MULTILANE_SOURCES})
 
+add_library(maliput_multilane::maliput_multilane ALIAS maliput_multilane)
+
+set_target_properties(maliput_multilane
+  PROPERTIES
+    OUTPUT_NAME maliput_multilane
+)
+
 target_include_directories(maliput_multilane
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/src/maliput_multilane_test_utilities/CMakeLists.txt
+++ b/src/maliput_multilane_test_utilities/CMakeLists.txt
@@ -3,14 +3,21 @@ set(TEST_UTILS_SOURCES
   multilane_brute_force_integral.cc
   multilane_types_compare.cc)
 
-add_library(maliput_multilane_test_utilities ${TEST_UTILS_SOURCES})
+add_library(test_utilities ${TEST_UTILS_SOURCES})
+
+add_library(maliput_multilane::test_utilities ALIAS test_utilities)
+
+set_target_properties(test_utilities
+  PROPERTIES
+    OUTPUT_NAME maliput_multilane_test_utilities
+)
 
 find_package(ament_cmake_gmock REQUIRED)
 
 ament_find_gmock()
 
 target_include_directories(
-  maliput_multilane_test_utilities
+  test_utilities
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
@@ -18,7 +25,7 @@ target_include_directories(
     ${GMOCK_INCLUDE_DIRS}
 )
 
-target_link_libraries(maliput_multilane_test_utilities
+target_link_libraries(test_utilities
   drake::drake
   maliput::api
   maliput::common
@@ -28,11 +35,11 @@ target_link_libraries(maliput_multilane_test_utilities
 )
 
 install(
-    TARGETS maliput_multilane_test_utilities
+    TARGETS test_utilities
     EXPORT ${PROJECT_NAME}-targets
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
     RUNTIME DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-ament_export_libraries(maliput_multilane_test_utilities)
+ament_export_libraries(test_utilities)

--- a/test/maliput_multilane/CMakeLists.txt
+++ b/test/maliput_multilane/CMakeLists.txt
@@ -28,8 +28,9 @@ macro(add_dependencies_to_test target)
           maliput::api
           maliput::common
           maliput::math
-          maliput_multilane
-          maliput_multilane_test_utilities)
+          maliput_multilane::maliput_multilane
+          maliput_multilane::test_utilities
+      )
 
     endif()
 endmacro()


### PR DESCRIPTION
Relates to https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/146

- Uses "maliput_multilane::" for the namespace target.
- Uses "maliput_multilane_" for the library name as prefix.