### PR TITLE
Unifies cmake install paths.

### DIFF
--- a/src/maliput_multilane/CMakeLists.txt
+++ b/src/maliput_multilane/CMakeLists.txt
@@ -49,11 +49,11 @@ target_link_libraries(maliput_multilane
 ##############################################################################
 
 install(
-    TARGETS maliput_multilane
-    EXPORT ${PROJECT_NAME}-targets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+  TARGETS maliput_multilane
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 ament_export_libraries(maliput_multilane)

--- a/src/maliput_multilane_test_utilities/CMakeLists.txt
+++ b/src/maliput_multilane_test_utilities/CMakeLists.txt
@@ -35,11 +35,11 @@ target_link_libraries(test_utilities
 )
 
 install(
-    TARGETS test_utilities
-    EXPORT ${PROJECT_NAME}-targets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+  TARGETS test_utilities
+  EXPORT ${PROJECT_NAME}-targets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 ament_export_libraries(test_utilities)


### PR DESCRIPTION
Relates to https://github.com/ToyotaResearchInstitute/dsim-repos-index/issues/146

Pairs with https://github.com/ToyotaResearchInstitute/maliput/pull/371