### PR TITLE
Append library dirs to plugin test.

### DIFF
--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -1,11 +1,14 @@
 find_package(ament_cmake_gtest REQUIRED)
 
-set (LIBRARY_DIRS ${CMAKE_INSTALL_PREFIX}/../maliput_dragway/lib ${CMAKE_INSTALL_PREFIX}/../maliput_malidrive/lib)
 # The following test uses the maliput::plugin::MaliputPluginManager entity to load all the availables plugins.
 # Given that the LD_LIBRARY_PATH environment variable isn't correctly set up until setup.bash is sourced,
 # and to avoid sourcing that file just to run one test we should append the paths.
 # This allow to any other backend plugin to find its correspondant backend core library.
-ament_add_gtest(road_network_plugin road_network_plugin_test.cc APPEND_LIBRARY_DIRS ${LIBRARY_DIRS})
+ament_add_gtest(road_network_plugin road_network_plugin_test.cc
+    APPEND_LIBRARY_DIRS
+      ${CMAKE_INSTALL_PREFIX}/../maliput_dragway/lib
+      ${CMAKE_INSTALL_PREFIX}/../maliput_malidrive/lib
+)
 
 macro(add_dependencies_to_test target)
     if (TARGET ${target})


### PR DESCRIPTION
A bit of context:

 For each backend, a `libmaliput_xxxx_road_network.so` dynamic library is installed at the default location(`install/maliput/lib/maliput/plugins`), which is ok.

The problem comes when you for example run a `maliput_multilane` test that loads the dragway plugin dynamic library using the `MaliputPluginManager`.
Let's say that for example, you are loading `libmaliput_dragway_road_network.so`
 then this is the error that you would see: `libmaliput_dragway.so`: cannot open shared object file: No such file or directory
 
Of course, the `maliput_dragway_road_network` libary that holds a plugin implementation links internally to `maliput_dragway`   which can't be found because the env var `LD_LIBRARY_PATH` doesn't contain the `install/maliput_dragway/lib` path. It is added when doing source install/setup.bash.

**Solution:** Update the paths during test configuration. That way there is no need to source `setup.bash` for running the tests.

Pairs with:
https://github.com/ToyotaResearchInstitute/maliput-dragway/pull/26
https://github.com/ToyotaResearchInstitute/maliput_malidrive/pull/26