### PR TITLE
Foxy style fix part 2: reorder includes

### DIFF
--- a/include/maliput_multilane/connection.h
+++ b/include/maliput_multilane/connection.h
@@ -10,6 +10,7 @@
 
 #include <maliput/common/maliput_abort.h>
 #include <maliput/common/maliput_copyable.h>
+
 #include "maliput_multilane/road_curve.h"
 
 namespace maliput {

--- a/include/maliput_multilane/junction.h
+++ b/include/maliput_multilane/junction.h
@@ -8,6 +8,7 @@
 #include <maliput/api/road_geometry.h>
 #include <maliput/api/segment.h>
 #include <maliput/common/maliput_copyable.h>
+
 #include "maliput_multilane/road_curve.h"
 #include "maliput_multilane/segment.h"
 

--- a/include/maliput_multilane/lane.h
+++ b/include/maliput_multilane/lane.h
@@ -4,7 +4,6 @@
 #include <optional>
 
 #include <drake/common/eigen_types.h>
-
 #include <maliput/api/branch_point.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/segment.h>

--- a/include/maliput_multilane/multilane_onramp_merge.h
+++ b/include/maliput_multilane/multilane_onramp_merge.h
@@ -5,6 +5,7 @@
 
 #include <maliput/api/road_geometry.h>
 #include <maliput/common/maliput_copyable.h>
+
 #include "maliput_multilane/builder.h"
 #include "maliput_multilane/road_curve.h"
 

--- a/include/maliput_multilane/road_curve.h
+++ b/include/maliput_multilane/road_curve.h
@@ -5,13 +5,13 @@
 #include <utility>
 
 #include <Eigen/Dense>
-
 #include <drake/common/eigen_types.h>
 #include <drake/math/rotation_matrix.h>
 #include <drake/systems/analysis/antiderivative_function.h>
 #include <drake/systems/analysis/scalar_initial_value_problem.h>
 #include <maliput/api/lane_data.h>
 #include <maliput/common/maliput_copyable.h>
+
 #include "maliput_multilane/cubic_polynomial.h"
 
 namespace maliput {

--- a/include/maliput_multilane/road_geometry.h
+++ b/include/maliput_multilane/road_geometry.h
@@ -10,6 +10,7 @@
 #include <maliput/api/road_geometry.h>
 #include <maliput/common/maliput_copyable.h>
 #include <maliput/math/vector.h>
+
 #include "maliput_multilane/branch_point.h"
 #include "maliput_multilane/junction.h"
 

--- a/include/maliput_multilane/road_network_builder.h
+++ b/include/maliput_multilane/road_network_builder.h
@@ -1,10 +1,10 @@
 // Copyright 2021 Toyota Research Institute
 #pragma once
 
+#include <memory>
+
 #include <maliput/api/road_geometry.h>
 #include <maliput/api/road_network.h>
-
-#include <memory>
 
 namespace maliput {
 namespace multilane {

--- a/include/maliput_multilane_test_utilities/eigen_matrix_compare.h
+++ b/include/maliput_multilane_test_utilities/eigen_matrix_compare.h
@@ -6,7 +6,6 @@
 
 #include <Eigen/Dense>
 #include <gtest/gtest.h>
-
 #include <maliput/common/logger.h>
 #include <maliput/math/vector.h>
 

--- a/include/maliput_multilane_test_utilities/fixtures.h
+++ b/include/maliput_multilane_test_utilities/fixtures.h
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include <gtest/gtest.h>
-
 #include <maliput/api/road_geometry.h>
 
 namespace maliput {

--- a/include/maliput_multilane_test_utilities/multilane_types_compare.h
+++ b/include/maliput_multilane_test_utilities/multilane_types_compare.h
@@ -2,8 +2,8 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
 #include <maliput/test_utilities/maliput_types_compare.h>
+
 #include "maliput_multilane/builder.h"
 #include "maliput_multilane/connection.h"
 

--- a/src/maliput_multilane/arc_road_curve.cc
+++ b/src/maliput_multilane/arc_road_curve.cc
@@ -4,7 +4,6 @@
 #include <limits>
 
 #include <drake/math/saturate.h>
-
 #include <maliput/common/maliput_abort.h>
 
 namespace maliput {

--- a/src/maliput_multilane/connection.cc
+++ b/src/maliput_multilane/connection.cc
@@ -1,6 +1,7 @@
 #include "maliput_multilane/connection.h"
 
 #include <drake/common/eigen_types.h>
+
 #include "maliput_multilane/arc_road_curve.h"
 #include "maliput_multilane/line_road_curve.h"
 

--- a/src/maliput_multilane/loader.cc
+++ b/src/maliput_multilane/loader.cc
@@ -9,11 +9,10 @@
 #include <tuple>
 #include <utility>
 
-#include <yaml-cpp/yaml.h>
-
 #include <maliput/common/logger.h>
 #include <maliput/common/maliput_abort.h>
 #include <maliput/common/maliput_throw.h>
+#include <yaml-cpp/yaml.h>
 
 #include "maliput_multilane/builder.h"
 #include "maliput_multilane/connection.h"

--- a/src/maliput_multilane/road_curve.cc
+++ b/src/maliput_multilane/road_curve.cc
@@ -5,7 +5,6 @@
 
 #include <drake/systems/analysis/integrator_base.h>
 #include <drake/systems/analysis/scalar_dense_output.h>
-
 #include <maliput/common/maliput_abort.h>
 #include <maliput/common/maliput_throw.h>
 #include <maliput/common/maliput_unused.h>

--- a/src/maliput_multilane/road_network_builder.cc
+++ b/src/maliput_multilane/road_network_builder.cc
@@ -15,11 +15,10 @@
 #include <maliput/base/traffic_light_book_loader.h>
 #include <maliput/common/logger.h>
 #include <maliput/common/maliput_abort.h>
+#include <yaml-cpp/yaml.h>
 
 #include "maliput_multilane/builder.h"
 #include "maliput_multilane/loader.h"
-
-#include <yaml-cpp/yaml.h>
 
 namespace maliput {
 namespace multilane {

--- a/src/maliput_multilane_test_utilities/fixtures.cc
+++ b/src/maliput_multilane_test_utilities/fixtures.cc
@@ -5,6 +5,7 @@
 
 #include <maliput/api/lane.h>
 #include <maliput/common/filesystem.h>
+
 #include "maliput_multilane/builder.h"
 #include "maliput_multilane/loader.h"
 

--- a/src/plugin/road_network.cc
+++ b/src/plugin/road_network.cc
@@ -2,6 +2,7 @@
 #include <memory>
 
 #include <maliput/plugin/road_network_loader.h>
+
 #include "maliput_multilane/road_network_builder.h"
 
 namespace maliput {

--- a/test/maliput_multilane/2x2_intersection_test.cc
+++ b/test/maliput_multilane/2x2_intersection_test.cc
@@ -1,19 +1,18 @@
+#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include <gtest/gtest.h>
-
 #include <maliput/api/branch_point.h>
 #include <maliput/api/junction.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/lane_data.h>
 #include <maliput/api/road_geometry.h>
 #include <maliput/common/filesystem.h>
+
 #include "maliput_multilane/builder.h"
 #include "maliput_multilane/loader.h"
-
-#include <iostream>
 
 namespace maliput {
 namespace multilane {

--- a/test/maliput_multilane/multilane_arc_road_curve_test.cc
+++ b/test/maliput_multilane/multilane_arc_road_curve_test.cc
@@ -3,9 +3,9 @@
 /* clang-format on */
 
 #include <gtest/gtest.h>
-
 #include <maliput/api/lane_data.h>
 #include <maliput/common/assertion_error.h>
+
 #include "maliput_multilane_test_utilities/eigen_matrix_compare.h"
 
 namespace maliput {

--- a/test/maliput_multilane/multilane_builder_test.cc
+++ b/test/maliput_multilane/multilane_builder_test.cc
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include <gtest/gtest.h>
-
 #include <maliput/api/lane_data.h>
 #include <maliput/common/assertion_error.h>
 #include <maliput/common/maliput_copyable.h>
@@ -17,6 +16,7 @@
 #include <maliput/math/vector.h>
 #include <maliput/test_utilities/check_id_indexing.h>
 #include <maliput/test_utilities/maliput_types_compare.h>
+
 #include "maliput_multilane_test_utilities/multilane_types_compare.h"
 
 namespace maliput {

--- a/test/maliput_multilane/multilane_connection_test.cc
+++ b/test/maliput_multilane/multilane_connection_test.cc
@@ -7,8 +7,8 @@
 
 #include <fmt/format.h>
 #include <gtest/gtest.h>
-
 #include <maliput/math/vector.h>
+
 #include "maliput_multilane/arc_road_curve.h"
 #include "maliput_multilane/cubic_polynomial.h"
 #include "maliput_multilane/line_road_curve.h"

--- a/test/maliput_multilane/multilane_lanes_test.cc
+++ b/test/maliput_multilane/multilane_lanes_test.cc
@@ -6,8 +6,8 @@
 #include <map>
 
 #include <gtest/gtest.h>
-
 #include <maliput/test_utilities/maliput_types_compare.h>
+
 #include "maliput_multilane/arc_road_curve.h"
 #include "maliput_multilane/junction.h"
 #include "maliput_multilane/line_road_curve.h"

--- a/test/maliput_multilane/multilane_line_road_curve_test.cc
+++ b/test/maliput_multilane/multilane_line_road_curve_test.cc
@@ -5,10 +5,10 @@
 #include <utility>
 
 #include <gtest/gtest.h>
-
 #include <maliput/api/lane_data.h>
 #include <maliput/common/assertion_error.h>
 #include <maliput/math/vector.h>
+
 #include "maliput_multilane_test_utilities/eigen_matrix_compare.h"
 
 namespace maliput {

--- a/test/maliput_multilane/multilane_loader_test.cc
+++ b/test/maliput_multilane/multilane_loader_test.cc
@@ -12,13 +12,13 @@
 #include <fmt/format.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-
 #include <maliput/api/branch_point.h>
 #include <maliput/api/junction.h>
 #include <maliput/api/lane.h>
 #include <maliput/api/road_geometry.h>
 #include <maliput/api/segment.h>
 #include <maliput/test_utilities/maliput_types_compare.h>
+
 #include "maliput_multilane/builder.h"
 #include "maliput_multilane/connection.h"
 #include "maliput_multilane_test_utilities/multilane_types_compare.h"

--- a/test/maliput_multilane/multilane_road_curve_accuracy_test.cc
+++ b/test/maliput_multilane/multilane_road_curve_accuracy_test.cc
@@ -9,8 +9,8 @@
 
 #include <fmt/format.h>
 #include <gtest/gtest.h>
-
 #include <maliput/math/vector.h>
+
 #include "maliput_multilane/arc_road_curve.h"
 #include "maliput_multilane/cubic_polynomial.h"
 #include "maliput_multilane/line_road_curve.h"

--- a/test/maliput_multilane/multilane_road_geometry_test.cc
+++ b/test/maliput_multilane/multilane_road_geometry_test.cc
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include <gtest/gtest.h>
-
 #include <maliput/common/maliput_abort.h>
 #include <maliput/test_utilities/maliput_types_compare.h>
 

--- a/test/maliput_multilane/multilane_segments_test.cc
+++ b/test/maliput_multilane/multilane_segments_test.cc
@@ -3,9 +3,9 @@
 /* clang-format on */
 
 #include <gtest/gtest.h>
-
 #include <maliput/math/vector.h>
 #include <maliput/test_utilities/maliput_types_compare.h>
+
 #include "maliput_multilane/arc_road_curve.h"
 #include "maliput_multilane/junction.h"
 #include "maliput_multilane/lane.h"

--- a/test/maliput_multilane/yaml_load.cc
+++ b/test/maliput_multilane/yaml_load.cc
@@ -5,11 +5,11 @@
 #include <iostream>
 #include <string>
 
-#include <gflags/gflags.h>
-
 #include <drake/common/text_logging.h>
+#include <gflags/gflags.h>
 #include <maliput/api/road_geometry.h>
 #include <maliput/common/logger.h>
+
 #include "maliput_multilane/builder.h"
 #include "maliput_multilane/loader.h"
 

--- a/test/plugin/road_network_plugin_test.cc
+++ b/test/plugin/road_network_plugin_test.cc
@@ -4,7 +4,6 @@
 #include <string>
 
 #include <gtest/gtest.h>
-
 #include <maliput/common/filesystem.h>
 #include <maliput/plugin/maliput_plugin.h>
 #include <maliput/plugin/maliput_plugin_manager.h>


### PR DESCRIPTION
Also use `<>` for yaml-cpp includes, which I forgot to include in #57. Part of https://github.com/ToyotaResearchInstitute/maliput_infrastructure/issues/196