### PR TITLE
Remove references to GNUInstallDir vars.

### DIFF
--- a/src/maliput_multilane/CMakeLists.txt
+++ b/src/maliput_multilane/CMakeLists.txt
@@ -30,7 +30,8 @@ set_target_properties(maliput_multilane
 target_include_directories(maliput_multilane
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    $<INSTALL_INTERFACE:include>
+)
 
 ament_target_dependencies(maliput_multilane
   "maliput"

--- a/src/maliput_multilane_test_utilities/CMakeLists.txt
+++ b/src/maliput_multilane_test_utilities/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(
   test_utilities
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<INSTALL_INTERFACE:include>
   PRIVATE
     ${GMOCK_INCLUDE_DIRS}
 )

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -19,7 +19,8 @@ target_link_libraries(road_network
 target_include_directories(road_network
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    $<INSTALL_INTERFACE:include>
+)
 
 ##############################################################################
 # Export


### PR DESCRIPTION
Because it is not brought by default in ROS2 foxy,
we can just use the name of the folder 'include'
to reference where to look at for include directories.

Part of ToyotaResearchInstitute/maliput_infrastructure#196

Solves ToyotaResearchInstitute/maliput_dragway#52