### PR TITLE
Removes ament_target_dependencies macro.

### DIFF
--- a/src/maliput_multilane/CMakeLists.txt
+++ b/src/maliput_multilane/CMakeLists.txt
@@ -33,11 +33,6 @@ target_include_directories(maliput_multilane
     $<INSTALL_INTERFACE:include>
 )
 
-ament_target_dependencies(maliput_multilane
-  "maliput"
-  "drake"
-)
-
 target_link_libraries(maliput_multilane
   drake::drake
   maliput::api

--- a/test/maliput_multilane/CMakeLists.txt
+++ b/test/maliput_multilane/CMakeLists.txt
@@ -18,11 +18,6 @@ macro(add_dependencies_to_test target)
           ${PROJECT_SOURCE_DIR}/include
       )
 
-      ament_target_dependencies(${target}
-          "maliput"
-          "drake"
-      )
-
       target_link_libraries(${target}
           drake::drake
           maliput::api

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -25,10 +25,6 @@ macro(add_dependencies_to_test target)
           ENABLE_EXPORTS ON
       )
 
-      ament_target_dependencies(${target}
-        "maliput"
-      )
-
       target_link_libraries(${target}
           maliput_multilane::maliput_multilane
           maliput::common


### PR DESCRIPTION
Removes pending calls to `ament_target_dependencies()`

It manifested in a very strange way. See this [build run](https://github.com/ToyotaResearchInstitute/delphyne/pull/792/checks?check_run_id=3127652097) and the relevant log:

```sh
    ============================= test session starts ==============================
    platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
    rootdir: /__w/delphyne/delphyne/maliput_ws
    plugins: ament-lint-0.9.6, ament-flake8-0.9.6, repeat-0.9.1, mock-3.6.1, rerunfailures-10.1, cov-2.12.1, colcon-core-0.6.1
    collected 0 items / 1 error
    
    ==================================== ERRORS ====================================
    _ ERROR collecting src/delphyne/test/regression/python/simulation_runner_py_test.py _
    ImportError while importing test module '/__w/delphyne/delphyne/maliput_ws/src/delphyne/test/regression/python/simulation_runner_py_test.py'.
    Hint: make sure your test modules/packages have valid Python names.
    Traceback:
    /usr/lib/python3.8/importlib/__init__.py:127: in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
    ../../../../../src/delphyne/test/regression/python/simulation_runner_py_test.py:14: in <module>
        from delphyne.agents import SimpleCarBlueprint
    E   ImportError: /__w/delphyne/delphyne/maliput_ws/install/maliput/lib/libmaliput_test_utilities.so: undefined symbol: _ZN7testing16AssertionSuccessEv
    =========================== short test summary info ============================
    ERROR ../../../../../src/delphyne/test/regression/python/simulation_runner_py_test.py
    !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
    =============================== 1 error in 0.23s ===============================
  >>>
```

Locally, it manifested in the same way but with another library that was not part of any `target_include_libraries()` within delphyne.

This PR should enable https://github.com/ToyotaResearchInstitute/delphyne/pull/792