### PR TITLE
Improves use of maliput plugin architecture.

### DIFF
--- a/setup.sh.in
+++ b/setup.sh.in
@@ -53,3 +53,6 @@ add_if_not_in_var() {
 # Path to various resources used by shell/python scripts and demos
 #   e.g. configuration files, protos, road geometries
 add_if_not_in_var MULTILANE_RESOURCE_ROOT $COLCON_PREFIX_PATH/maliput_multilane/share/maliput_multilane
+
+# Extends path for the maliput plugin architecture
+add_if_not_in_var MALIPUT_PLUGIN_PATH $COLCON_PREFIX_PATH/maliput_multilane/lib/plugins:$MALIPUT_PLUGIN_PATH

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -26,8 +26,11 @@ target_include_directories(road_network
 # Export
 ##############################################################################
 
+# Using a different location as this target is a dynamic library
+# which will be loaded in runtime as a maliput plugin.
 set(PLUGIN_INSTALL_DIR
-    "${CMAKE_INSTALL_PREFIX}/../maliput/lib/maliput/plugins")
+    lib/plugins
+)
 
 install(
   TARGETS road_network

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -1,14 +1,6 @@
 find_package(ament_cmake_gtest REQUIRED)
 
-# The following test uses the maliput::plugin::MaliputPluginManager entity to load all the availables plugins.
-# Given that the LD_LIBRARY_PATH environment variable isn't correctly set up until setup.bash is sourced,
-# and to avoid sourcing that file just to run one test we should append the paths.
-# This allow to any other backend plugin to find its correspondant backend core library.
-ament_add_gtest(road_network_plugin road_network_plugin_test.cc
-    APPEND_LIBRARY_DIRS
-      ${CMAKE_INSTALL_PREFIX}/../maliput_dragway/lib
-      ${CMAKE_INSTALL_PREFIX}/../maliput_malidrive/lib
-)
+ament_add_gtest(road_network_plugin road_network_plugin_test.cc)
 
 macro(add_dependencies_to_test target)
     if (TARGET ${target})


### PR DESCRIPTION
Improves use of maliput plugin architecture:
 - Change Install folder where the `maliput::plugin::RoadNetworkLoader` is installed
 - Extends `MALIPUT_PLUGIN_PATH` env var to use the discovery process of the plugins as the documentation recommends.