### PR TITLE
Fixes MALIPUT_PLUGIN_PATH new path.

### DIFF
--- a/setup.sh.in
+++ b/setup.sh.in
@@ -55,4 +55,4 @@ add_if_not_in_var() {
 add_if_not_in_var MULTILANE_RESOURCE_ROOT $COLCON_PREFIX_PATH/maliput_multilane/share/maliput_multilane
 
 # Extends path for the maliput plugin architecture
-add_if_not_in_var MALIPUT_PLUGIN_PATH $COLCON_PREFIX_PATH/maliput_multilane/lib/plugins:$MALIPUT_PLUGIN_PATH
+add_if_not_in_var MALIPUT_PLUGIN_PATH $COLCON_PREFIX_PATH/maliput_multilane/lib/plugins


### PR DESCRIPTION
the `add_if_not_in_var` function in `setup.sh.ini` already extend the variable.

It was added at #74 