### PR TITLE
Extends RoadNetworkLoader plugin

### DIFF
--- a/include/maliput_multilane/road_network_builder.h
+++ b/include/maliput_multilane/road_network_builder.h
@@ -6,18 +6,33 @@
 #include <maliput/api/road_geometry.h>
 #include <maliput/api/road_network.h>
 
+#include "maliput_multilane/multilane_onramp_merge.h"
+
 namespace maliput {
 namespace multilane {
 
 /// Contains the attributes needed for building a api::RoadNetwork.
 struct RoadNetworkConfiguration {
+  /// Path to a YAML description file.
   std::string yaml_file{""};
+  /// Serialized YAML description.
+  std::string yaml_description{""};
 };
 
 /// Builds an api::RoadNetwork based on multilane implementation.
 /// @param road_network_configuration Holds the properties to build the RoadNetwork.
+///                                   When `road_network_configuration.yaml_file` is empty,
+///                                   `road_network_configuration.yaml_description` will be used instead.
 /// @return A maliput::api::RoadNetwork.
-std::unique_ptr<const api::RoadNetwork> BuildRoadNetwork(const RoadNetworkConfiguration& road_network_configuration);
+/// @throws maliput::common::assertion_error When both `road_network_configuration.yaml_file` and
+/// `road_network_configuration.yaml_description` are empty.
+std::unique_ptr<api::RoadNetwork> BuildRoadNetwork(const RoadNetworkConfiguration& road_network_configuration);
+
+/// Builds an api::RoadNetwork based on MultilaneOnrampMerge implementation.
+/// Rulebook and related entities are only set to correctly build the RoadNetwork but they are expected to be empty.
+/// @param road_characteristics Holds the properties to build a MultilaneOnrampMerge.
+/// @return A maliput::api::RoadNetwork.
+std::unique_ptr<api::RoadNetwork> BuildOnRampMergeRoadNetwork(const MultilaneRoadCharacteristics& road_characteristics);
 
 }  // namespace multilane
 }  // namespace maliput

--- a/src/maliput_multilane/road_network_builder.cc
+++ b/src/maliput_multilane/road_network_builder.cc
@@ -22,20 +22,97 @@
 
 namespace maliput {
 namespace multilane {
+namespace {
 
-std::unique_ptr<const api::RoadNetwork> BuildRoadNetwork(const RoadNetworkConfiguration& build_properties) {
+// @returns true if `node` contains a subnode named "RoadRulebook".
+bool IsRoadRulebookNodeDefined(const YAML::Node& node) {
+  const YAML::Node& rulebook_node = node["RoadRulebook"];
+  return rulebook_node.IsDefined();
+}
+
+// @returns true if `node` contains a subnode named "TrafficLights".
+bool IsTrafficLightsNodeDefined(const YAML::Node& node) {
+  const YAML::Node& rulebook_node = node["TrafficLights"];
+  return rulebook_node.IsDefined();
+}
+
+// @returns true if `node` contains a subnode named "PhaseRings".
+bool IsPhaseRingsNodeDefined(const YAML::Node& node) {
+  const YAML::Node& rulebook_node = node["PhaseRings"];
+  return rulebook_node.IsDefined();
+}
+
+// @returns true if `node` contains a subnode named "Intersections".
+bool IsIntersectionsNodeDefined(const YAML::Node& node) {
+  const YAML::Node& rulebook_node = node["Intersections"];
+  return rulebook_node.IsDefined();
+}
+
+}  // namespace
+
+std::unique_ptr<api::RoadNetwork> BuildRoadNetwork(const RoadNetworkConfiguration& road_network_configuration) {
   maliput::log()->debug("Building multilane RoadNetwork.");
-  if (build_properties.yaml_file.empty()) {
-    MALIPUT_ABORT_MESSAGE("yaml_file cannot be empty.");
+
+  if (road_network_configuration.yaml_file.empty() && road_network_configuration.yaml_description.empty()) {
+    MALIPUT_ABORT_MESSAGE("Both yaml_file and yaml_description cannot be empty.");
   }
-  auto rg = LoadFile(BuilderFactory(), build_properties.yaml_file);
-  auto rulebook = LoadRoadRulebookFromFile(rg.get(), build_properties.yaml_file);
-  auto traffic_light_book = LoadTrafficLightBookFromFile(build_properties.yaml_file);
-  auto phase_ring_book =
-      LoadPhaseRingBookFromFile(rulebook.get(), traffic_light_book.get(), build_properties.yaml_file);
+  auto yaml_root_node = !road_network_configuration.yaml_file.empty()
+                            ? YAML::LoadFile(road_network_configuration.yaml_file)
+                            : YAML::Load(road_network_configuration.yaml_description);
+  auto rg = !road_network_configuration.yaml_file.empty()
+                ? LoadFile(BuilderFactory(), road_network_configuration.yaml_file)
+                : Load(BuilderFactory(), road_network_configuration.yaml_description);
+
+  auto rulebook = IsRoadRulebookNodeDefined(yaml_root_node)
+                      ? (!road_network_configuration.yaml_file.empty()
+                             ? LoadRoadRulebookFromFile(rg.get(), road_network_configuration.yaml_file)
+                             : LoadRoadRulebook(rg.get(), road_network_configuration.yaml_description))
+                      : std::make_unique<ManualRulebook>();
+  auto traffic_light_book = IsTrafficLightsNodeDefined(yaml_root_node)
+                                ? (!road_network_configuration.yaml_file.empty()
+                                       ? LoadTrafficLightBookFromFile(road_network_configuration.yaml_file)
+                                       : LoadTrafficLightBook(road_network_configuration.yaml_description))
+                                : std::make_unique<TrafficLightBook>();
+  auto phase_ring_book = IsPhaseRingsNodeDefined(yaml_root_node)
+                             ? (!road_network_configuration.yaml_file.empty()
+                                    ? LoadPhaseRingBookFromFile(rulebook.get(), traffic_light_book.get(),
+                                                                road_network_configuration.yaml_file)
+                                    : LoadPhaseRingBook(rulebook.get(), traffic_light_book.get(),
+                                                        road_network_configuration.yaml_description))
+                             : std::make_unique<ManualPhaseRingBook>();
   std::unique_ptr<ManualPhaseProvider> phase_provider = std::make_unique<ManualPhaseProvider>();
-  auto intersection_book =
-      LoadIntersectionBookFromFile(build_properties.yaml_file, *rulebook, *phase_ring_book, phase_provider.get());
+  auto intersection_book = IsIntersectionsNodeDefined(yaml_root_node)
+                               ? (!road_network_configuration.yaml_file.empty()
+                                      ? LoadIntersectionBookFromFile(road_network_configuration.yaml_file, *rulebook,
+                                                                     *phase_ring_book, phase_provider.get())
+                                      : LoadIntersectionBook(road_network_configuration.yaml_file, *rulebook,
+                                                             *phase_ring_book, phase_provider.get()))
+                               : std::make_unique<IntersectionBook>();
+  std::unique_ptr<api::rules::RuleRegistry> rule_registry = std::make_unique<api::rules::RuleRegistry>();
+
+  std::unique_ptr<ManualRightOfWayRuleStateProvider> right_of_way_rule_state_provider =
+      std::make_unique<ManualRightOfWayRuleStateProvider>();
+  std::unique_ptr<ManualDiscreteValueRuleStateProvider> discrete_value_rule_state_provider =
+      std::make_unique<ManualDiscreteValueRuleStateProvider>(rulebook.get());
+  std::unique_ptr<ManualRangeValueRuleStateProvider> range_value_rule_state_provider =
+      std::make_unique<ManualRangeValueRuleStateProvider>(rulebook.get());
+  return std::make_unique<api::RoadNetwork>(std::move(rg), std::move(rulebook), std::move(traffic_light_book),
+                                            std::move(intersection_book), std::move(phase_ring_book),
+                                            std::move(right_of_way_rule_state_provider), std::move(phase_provider),
+                                            std::move(rule_registry), std::move(discrete_value_rule_state_provider),
+                                            std::move(range_value_rule_state_provider));
+}
+
+std::unique_ptr<api::RoadNetwork> BuildOnRampMergeRoadNetwork(
+    const MultilaneRoadCharacteristics& road_characteristics) {
+  maliput::log()->debug("Building multilane onramp merge RoadNetwork.");
+  auto rg = maliput::multilane::MultilaneOnrampMerge(road_characteristics).BuildOnramp();
+  auto rulebook = std::make_unique<ManualRulebook>();
+  auto traffic_light_book = std::make_unique<TrafficLightBook>();
+  auto phase_ring_book = std::make_unique<ManualPhaseRingBook>();
+  auto result = std::make_unique<ManualPhaseRingBook>();
+  auto phase_provider = std::make_unique<ManualPhaseProvider>();
+  auto intersection_book = std::make_unique<IntersectionBook>();
   std::unique_ptr<api::rules::RuleRegistry> rule_registry = std::make_unique<api::rules::RuleRegistry>();
 
   std::unique_ptr<ManualRightOfWayRuleStateProvider> right_of_way_rule_state_provider =

--- a/src/plugin/road_network.cc
+++ b/src/plugin/road_network.cc
@@ -1,8 +1,10 @@
 // Copyright 2021 Toyota Research Institute
 #include <memory>
 
+#include <maliput/common/maliput_abort.h>
 #include <maliput/plugin/road_network_loader.h>
 
+#include "maliput_multilane/multilane_onramp_merge.h"
 #include "maliput_multilane/road_network_builder.h"
 
 namespace maliput {
@@ -14,19 +16,66 @@ namespace {
 // @param parameters  A dictionary of properties to fill in a multilane::RoadNetworkConfiguration struct.
 //                    Keys are the names of attributes in multilane::RoadNetworkConfiguration.
 // @returns A multilane::RoadNetworkConfiguration.
-maliput::multilane::RoadNetworkConfiguration GetPropertiesFromStringMap(
+maliput::multilane::RoadNetworkConfiguration GetRoadNetworkPropertiesFromStringMap(
     const std::map<std::string, std::string>& parameters) {
   auto it = parameters.find("yaml_file");
   const std::string yaml_file = it != parameters.end() ? it->second : "";
-  return {yaml_file};
+
+  it = parameters.find("yaml_description");
+  const std::string yaml_description = it != parameters.end() ? it->second : "";
+  return {yaml_file, yaml_description};
+}
+
+// Return a multilane::MultilaneRoadCharacteristics object out of a map of strings.
+// @param parameters  A dictionary of properties to fill in a multilane::MultilaneRoadCharacteristics struct.
+//                    Keys are the names of attributes in multilane::MultilaneRoadCharacteristics.
+// @returns A multilane::MultilaneRoadCharacteristics.
+maliput::multilane::MultilaneRoadCharacteristics GetOnRampPropertiesFromStringMap(
+    const std::map<std::string, std::string>& parameters) {
+  MultilaneRoadCharacteristics default_on_ramp_params{};
+  auto it = parameters.find("lane_width");
+  const double lane_width = it != parameters.end() ? std::stod(it->second) : default_on_ramp_params.lane_width;
+
+  it = parameters.find("left_shoulder");
+  const double left_shoulder = it != parameters.end() ? std::stod(it->second) : default_on_ramp_params.left_shoulder;
+
+  it = parameters.find("right_shoulder");
+  const double right_shoulder = it != parameters.end() ? std::stod(it->second) : default_on_ramp_params.right_shoulder;
+
+  it = parameters.find("lane_number");
+  const int lane_number = it != parameters.end() ? std::stoi(it->second) : default_on_ramp_params.lane_number;
+
+  return {lane_width, left_shoulder, right_shoulder, lane_number};
+}
+
+// Builds a maliput::api::RoadNetwork depending on `properties`.
+// A 'road_network_source' flag is used to differentiate which multilane implementation will be used:
+//    1. The base multilane builder loaded from a yaml file or a serialized yaml description.
+//    2. The MultilaneOnRampMerge builder.
+std::unique_ptr<maliput::api::RoadNetwork> BuildRoadNetworkFromParams(
+    const std::map<std::string, std::string>& properties) {
+  auto it = properties.find("road_network_source");
+  if (it == properties.end()) {
+    MALIPUT_THROW_MESSAGE("'road_network_source' parameter is missing: 'yaml' or 'on_ramp_merge' should be selected.");
+  }
+  const std::string source = it->second;
+  if (source == "yaml") {
+    return maliput::multilane::BuildRoadNetwork(GetRoadNetworkPropertiesFromStringMap(properties));
+  } else if (source == "on_ramp_merge") {
+    return maliput::multilane::BuildOnRampMergeRoadNetwork(GetOnRampPropertiesFromStringMap(properties));
+  } else {
+    MALIPUT_THROW_MESSAGE(
+        "'road_network_source' parameter doesn't contain a valid source: 'yaml' or 'on_ramp_merge' should be "
+        "selected.");
+  }
 }
 
 // Implementation of a maliput::plugin::RoadNetworkLoader using multilane backend.
 class RoadNetworkLoader : public maliput::plugin::RoadNetworkLoader {
  public:
-  std::unique_ptr<const maliput::api::RoadNetwork> operator()(
+  std::unique_ptr<maliput::api::RoadNetwork> operator()(
       const std::map<std::string, std::string>& properties) const override {
-    return maliput::multilane::BuildRoadNetwork(GetPropertiesFromStringMap(properties));
+    return BuildRoadNetworkFromParams(properties);
   }
 };
 

--- a/test/plugin/road_network_plugin_test.cc
+++ b/test/plugin/road_network_plugin_test.cc
@@ -16,39 +16,106 @@ namespace maliput {
 namespace multilane {
 namespace {
 
-GTEST_TEST(RoadNetworkLoader, VerifyRoadNetworkPlugin) {
-  // Get absolute path to a yaml file to be used for testing.
-  const std::string MULTILANE_RESOURCE_ROOT{"MULTILANE_RESOURCE_ROOT"};
-  const std::string kFileName{"/2x2_intersection.yaml"};
-  const std::string env_path = maliput::common::Filesystem::get_env_path(MULTILANE_RESOURCE_ROOT);
-  ASSERT_TRUE(!env_path.empty());
+// Tests RoadNetworkLoader plugin.
+class RoadNetworkLoaderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_TRUE(!env_path_.empty());
+    // Check MaliputPlugin existence.
+    const plugin::MaliputPlugin* rn_plugin{manager_.GetPlugin(kMultilanePluginId)};
+    ASSERT_NE(nullptr, rn_plugin);
 
+    // Check multilane plugin is obtained.
+    EXPECT_EQ(kMultilanePluginId.string(), rn_plugin->GetId());
+    EXPECT_EQ(plugin::MaliputPluginType::kRoadNetworkLoader, rn_plugin->GetType());
+    maliput::plugin::RoadNetworkLoaderPtr rn_loader_ptr{nullptr};
+    ASSERT_NO_THROW(rn_loader_ptr = rn_plugin->ExecuteSymbol<plugin::RoadNetworkLoaderPtr>(
+                        plugin::RoadNetworkLoader::GetEntryPoint()));
+    ASSERT_NE(nullptr, rn_loader_ptr);
+    rn_loader_.reset(reinterpret_cast<maliput::plugin::RoadNetworkLoader*>(rn_loader_ptr));
+  }
+
+  void CheckMultilaneRoadNetworkIsConstructible(const std::map<std::string, std::string>& rg_multilane_properties) {
+    std::unique_ptr<const maliput::api::RoadNetwork> rn;
+    (*rn_loader_)(rg_multilane_properties);
+    ASSERT_NO_THROW(rn = (*rn_loader_)(rg_multilane_properties));
+    ASSERT_NE(nullptr, rn);
+    auto multilane_rg = dynamic_cast<const RoadGeometry*>(rn->road_geometry());
+    ASSERT_NE(nullptr, multilane_rg);
+  }
+
+  const std::string MULTILANE_RESOURCE_ROOT{"MULTILANE_RESOURCE_ROOT"};
   // RoadNetworkLoader plugin id.
   const plugin::MaliputPlugin::Id kMultilanePluginId{"maliput_multilane"};
+
+  const std::string env_path_ = maliput::common::Filesystem::get_env_path(MULTILANE_RESOURCE_ROOT);
+  maliput::plugin::MaliputPluginManager manager_{};
+  std::unique_ptr<maliput::plugin::RoadNetworkLoader> rn_loader_{nullptr};
+};
+
+// Tests loading a RoadGeometry using a yaml file.
+TEST_F(RoadNetworkLoaderTest, UsingYamlFile) {
+  // Get absolute path to a yaml file to be used for testing.
+  const std::string kFileName{"/2x2_intersection.yaml"};
+  // Multilane properties.
+  const std::map<std::string, std::string> rg_multilane_properties{{"road_network_source", "yaml"},
+                                                                   {"yaml_file", env_path_ + kFileName}};
+  CheckMultilaneRoadNetworkIsConstructible(rg_multilane_properties);
+}
+
+// Tests loading a RoadGeometry using a serialized yaml description.
+TEST_F(RoadNetworkLoaderTest, UsingYamlDescription) {
+  // Yaml description based on "long_start_and_end_lanes" yaml file.
+  const std::string kYamlDescription{R"R(
+maliput_multilane_builder:
+  id: "long_start_and_end_lanes"
+  computation_policy: "prefer-accuracy"
+  scale_length: 1
+  lane_width: 6
+  left_shoulder: 5
+  right_shoulder: 5
+  elevation_bounds: [0, 5]
+  linear_tolerance: .01
+  angular_tolerance: 0.5
+  points:
+    start:
+      xypoint: [0, 0, 0]  # x,y, heading
+      zpoint: [0, 0, 0, 0]  # z, z_dot, theta (super-elevation), theta_dot
+  connections:
+    0:
+      lanes: [1, 0, 0]  # num_lanes, ref_lane, r_ref
+      start: ["ref", "points.start.forward"]
+      length: 1000
+      z_end: ["ref", [0, 0, 0]]
+    1:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.0.end.ref.forward"]
+      length: 10
+      z_end: ["ref", [0, 0, 0]]
+    2:
+      lanes: [1, 0, 0]
+      start: ["ref", "connections.1.end.ref.forward"]
+      length: 1000
+      z_end: ["ref", [0, 0, 0]]
+)R"};
+
   // Multilane properties needed for loading a road geometry.
-  const std::map<std::string, std::string> rg_multilane_properties{{"yaml_file", env_path + kFileName}};
+  const std::map<std::string, std::string> rg_multilane_properties{{"road_network_source", "yaml"},
+                                                                   {"yaml_description", kYamlDescription}};
+  CheckMultilaneRoadNetworkIsConstructible(rg_multilane_properties);
+}
 
-  // Check MaliputPlugin existence.
-  plugin::MaliputPluginManager manager{};
-  const plugin::MaliputPlugin* rn_plugin{manager.GetPlugin(kMultilanePluginId)};
-  ASSERT_NE(nullptr, rn_plugin);
-
-  // Check multilane plugin is obtained.
-  EXPECT_EQ(kMultilanePluginId.string(), rn_plugin->GetId());
-  EXPECT_EQ(plugin::MaliputPluginType::kRoadNetworkLoader, rn_plugin->GetType());
-  plugin::RoadNetworkLoaderPtr rn_loader_ptr{nullptr};
-  EXPECT_NO_THROW(rn_loader_ptr = rn_plugin->ExecuteSymbol<plugin::RoadNetworkLoaderPtr>(
-                      plugin::RoadNetworkLoader::GetEntryPoint()));
-  ASSERT_NE(nullptr, rn_loader_ptr);
-  std::unique_ptr<maliput::plugin::RoadNetworkLoader> rn_loader{
-      reinterpret_cast<plugin::RoadNetworkLoader*>(rn_loader_ptr)};
-
-  // Check multilane RoadNetwork is constructible.
-  std::unique_ptr<const maliput::api::RoadNetwork> rn;
-  EXPECT_NO_THROW(rn = (*rn_loader)(rg_multilane_properties));
-  ASSERT_NE(nullptr, rn);
-  auto multilane_rg = dynamic_cast<const RoadGeometry*>(rn->road_geometry());
-  ASSERT_NE(nullptr, multilane_rg);
+// Tests loading a RoadGeometry using the MultilaneOnRampMerge builder.
+TEST_F(RoadNetworkLoaderTest, UsingOnRampBuilder) {
+  // Multilane properties.
+  const std::map<std::string, std::string> rg_multilane_properties{
+      {"road_network_source", "on_ramp_merge"},
+      {"lane_width", "4."},
+      {"left_shoulder", "2."},
+      {"right_shoulder", "2."},
+      {"lane_number", "1"},
+  };
+  CheckMultilaneRoadNetworkIsConstructible(rg_multilane_properties);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
Part of [delphyne - Dinamically load maliput backends](https://github.com/ToyotaResearchInstitute/delphyne/issues/804).


See https://github.com/ToyotaResearchInstitute/delphyne/issues/804#issuecomment-940989346 for reference.

Extends RoadNetworkLoader plugin to allow:
 - Loading a `RoadNetwork` it from a yaml file.
 - Loading a `RoadNetwork` from a yaml descriptions.
 - Loading a `RoadNetwork` using the  `MultilaneOnRampeMerge` implementation.
 
 ## Notes
 - Also part of ToyotaResearchInstitute/maliput#443.