### PR TITLE
Fixes test utilities

### DIFF
--- a/src/maliput_multilane_test_utilities/CMakeLists.txt
+++ b/src/maliput_multilane_test_utilities/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(BUILD_TESTING)
+
+find_package(ament_cmake_gmock REQUIRED)
+ament_find_gmock()
+
 set(TEST_UTILS_SOURCES
   fixtures.cc
   multilane_types_compare.cc)
@@ -11,18 +16,14 @@ set_target_properties(test_utilities
     OUTPUT_NAME maliput_multilane_test_utilities
 )
 
-find_package(ament_cmake_gmock REQUIRED)
-
-ament_find_gmock()
-
 target_include_directories(
   test_utilities
   PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
   PRIVATE
-    ${GMOCK_INCLUDE_DIRS}
-)
+  ${GMOCK_INCLUDE_DIRS}
+  )
 
 target_link_libraries(test_utilities
   PUBLIC
@@ -46,3 +47,5 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
+
+endif()

--- a/src/maliput_multilane_test_utilities/CMakeLists.txt
+++ b/src/maliput_multilane_test_utilities/CMakeLists.txt
@@ -1,8 +1,3 @@
-if(BUILD_TESTING)
-
-find_package(ament_cmake_gmock REQUIRED)
-ament_find_gmock()
-
 set(TEST_UTILS_SOURCES
   fixtures.cc
   multilane_types_compare.cc)
@@ -16,19 +11,17 @@ set_target_properties(test_utilities
     OUTPUT_NAME maliput_multilane_test_utilities
 )
 
+find_package(ament_cmake_gmock REQUIRED)
+
+ament_find_gmock()
+
 target_include_directories(
   test_utilities
   PUBLIC
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
   PRIVATE
-  ${GMOCK_INCLUDE_DIRS}
-  )
-
-set(MULTILANE_RESOURCE_ROOT ${PROJECT_SOURCE_DIR}/resources/)
-target_compile_definitions(test_utilities
-  PRIVATE
-    DEF_MULTILANE_RESOURCE_ROOT="${MULTILANE_RESOURCE_ROOT}"
+    ${GMOCK_INCLUDE_DIRS}
 )
 
 target_link_libraries(test_utilities
@@ -53,5 +46,3 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
-
-endif()

--- a/src/maliput_multilane_test_utilities/fixtures.cc
+++ b/src/maliput_multilane_test_utilities/fixtures.cc
@@ -48,17 +48,20 @@ namespace multilane {
 constexpr char MULTILANE_RESOURCE_VAR[] = "MULTILANE_RESOURCE_ROOT";
 
 BranchAndMergeBasedTest::BranchAndMergeBasedTest()
-    : road_geometry_(LoadFile(BuilderFactory(), std::string(DEF_MULTILANE_RESOURCE_ROOT) + "/branch_and_merge.yaml")),
+    : road_geometry_(LoadFile(BuilderFactory(), maliput::common::Filesystem::get_env_path(MULTILANE_RESOURCE_VAR) +
+                                                    "/branch_and_merge.yaml")),
       index_(road_geometry_->ById()),
       total_length_(index_.GetLane(LaneId("l:1.1_0"))->length() + index_.GetLane(LaneId("l:1.2_0"))->length() +
                     index_.GetLane(LaneId("l:1.3_0"))->length()) {}
 
 LoopBasedTest::LoopBasedTest()
-    : road_geometry_(LoadFile(BuilderFactory(), std::string(DEF_MULTILANE_RESOURCE_ROOT) + "/loop.yaml")),
+    : road_geometry_(
+          LoadFile(BuilderFactory(), maliput::common::Filesystem::get_env_path(MULTILANE_RESOURCE_VAR) + "/loop.yaml")),
       index_(road_geometry_->ById()) {}
 
 MultiBranchBasedTest::MultiBranchBasedTest()
-    : road_geometry_(LoadFile(BuilderFactory(), std::string(DEF_MULTILANE_RESOURCE_ROOT) + "/multi_branch.yaml")),
+    : road_geometry_(LoadFile(
+          BuilderFactory(), maliput::common::Filesystem::get_env_path(MULTILANE_RESOURCE_VAR) + "/multi_branch.yaml")),
       index_(road_geometry_->ById()) {}
 
 }  // namespace multilane

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,32 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(ament_cmake_gmock REQUIRED)
+
+macro(add_dependencies_to_test target)
+    if (TARGET ${target})
+
+      target_include_directories(${target}
+        PRIVATE
+          ${PROJECT_SOURCE_DIR}/include
+      )
+
+      set(MULTILANE_RESOURCE_ROOT ${PROJECT_SOURCE_DIR}/resources/)
+      target_compile_definitions(${target}
+        PRIVATE
+          DEF_MULTILANE_RESOURCE_ROOT="${MULTILANE_RESOURCE_ROOT}"
+      )
+
+      target_link_libraries(${target}
+          maliput::api
+          maliput::common
+          maliput::math
+          maliput_drake::common
+          maliput_multilane::maliput_multilane
+          maliput_multilane::test_utilities
+      )
+
+    endif()
+endmacro()
+
 add_subdirectory(maliput_multilane)
+add_subdirectory(maliput_multilane_test_utilities)
 add_subdirectory(plugin)

--- a/test/maliput_multilane/CMakeLists.txt
+++ b/test/maliput_multilane/CMakeLists.txt
@@ -10,32 +10,6 @@ ament_add_gmock(multilane_builder_test multilane_builder_test.cc)
 ament_add_gmock(multilane_connection_test multilane_connection_test.cc)
 ament_add_gmock(multilane_loader_test multilane_loader_test.cc)
 
-macro(add_dependencies_to_test target)
-    if (TARGET ${target})
-
-      target_include_directories(${target}
-        PRIVATE
-          ${PROJECT_SOURCE_DIR}/include
-      )
-
-      set(MULTILANE_RESOURCE_ROOT ${PROJECT_SOURCE_DIR}/resources/)
-      target_compile_definitions(${target}
-        PRIVATE
-          DEF_MULTILANE_RESOURCE_ROOT="${MULTILANE_RESOURCE_ROOT}"
-      )
-
-      target_link_libraries(${target}
-          maliput::api
-          maliput::common
-          maliput::math
-          maliput_drake::common
-          maliput_multilane::maliput_multilane
-          maliput_multilane::test_utilities
-      )
-
-    endif()
-endmacro()
-
 add_dependencies_to_test(2x2_intersection_test)
 add_dependencies_to_test(multilane_arc_road_curve_test)
 add_dependencies_to_test(multilane_builder_test)

--- a/test/maliput_multilane_test_utilities/CMakeLists.txt
+++ b/test/maliput_multilane_test_utilities/CMakeLists.txt
@@ -1,0 +1,3 @@
+ament_add_gtest(fixtures_test fixtures_test.cc)
+
+add_dependencies_to_test(fixtures_test)

--- a/test/maliput_multilane_test_utilities/fixtures_test.cc
+++ b/test/maliput_multilane_test_utilities/fixtures_test.cc
@@ -44,15 +44,15 @@ class TestMultiBranchBasedTest : public MultiBranchBasedTest {};
 }  // namespace
 
 TEST_F(TestBranchAndMergeBasedTest, smoke_test) {
-  // This test is a smoke test for the fixture.
+  // This test is a smoke test to validate the test fixture constructor.
 }
 
 TEST_F(TestLoopBasedTest, smoke_test) {
-  // This test is a smoke test for the fixture.
+  // This test is a smoke test to validate the test fixture constructor.
 }
 
 TEST_F(TestMultiBranchBasedTest, smoke_test) {
-  // This test is a smoke test for the fixture.
+ // This test is a smoke test to validate the test fixture constructor.
 }
 
 }  // namespace test

--- a/test/maliput_multilane_test_utilities/fixtures_test.cc
+++ b/test/maliput_multilane_test_utilities/fixtures_test.cc
@@ -1,0 +1,60 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, Woven Planet.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "maliput_multilane_test_utilities/fixtures.h"
+
+namespace maliput {
+namespace multilane {
+namespace test {
+
+namespace {
+
+class TestBranchAndMergeBasedTest : public BranchAndMergeBasedTest {};
+
+class TestLoopBasedTest : public LoopBasedTest {};
+
+class TestMultiBranchBasedTest : public MultiBranchBasedTest {};
+
+}  // namespace
+
+TEST_F(TestBranchAndMergeBasedTest, smoke_test) {
+  // This test is a smoke test for the fixture.
+}
+
+TEST_F(TestLoopBasedTest, smoke_test) {
+  // This test is a smoke test for the fixture.
+}
+
+TEST_F(TestMultiBranchBasedTest, smoke_test) {
+  // This test is a smoke test for the fixture.
+}
+
+}  // namespace test
+}  // namespace multilane
+}  // namespace maliput


### PR DESCRIPTION
### Summary

These test utilities are expected to be used by other packages, therefore we can't rely on a compile definition that points towards `${PROJECT_SOURCE_DIR}`. Let's use the env variable.

[This PR](https://github.com/maliput/maliput_integration_tests/pull/68) is failing in the ros build farm because of this.