### PR TITLE
Matches with changes in Maliput: Lane::ToLanePosition.

### DIFF
--- a/src/maliput_multilane/lane.cc
+++ b/src/maliput_multilane/lane.cc
@@ -100,11 +100,20 @@ api::LanePosition Lane::DoEvalMotionDerivatives(const api::LanePosition& positio
 }
 
 api::LanePositionResult Lane::DoToLanePosition(const api::InertialPosition& inertial_position) const {
+  return InertialToLaneSegmentPositionBackend(inertial_position, true);
+}
+
+api::LanePositionResult Lane::DoToSegmentPosition(const api::InertialPosition& inertial_position) const {
+  return InertialToLaneSegmentPositionBackend(inertial_position, false);
+}
+
+api::LanePositionResult Lane::InertialToLaneSegmentPositionBackend(const api::InertialPosition& inertial_position,
+                                                                   bool use_lane_boundaries) const {
   // Computes the lateral extents of the surface in terms of the definition of
-  // the reference curve. It implies a translation of the segment bounds
+  // the reference curve. It implies a translation of the lane bounds
   // center by the lane by r0 distance.
-  const double r_min = segment_bounds_.min() + r0_;
-  const double r_max = segment_bounds_.max() + r0_;
+  const double r_min = (use_lane_boundaries ? lane_bounds_.min() : segment_bounds_.min()) + r0_;
+  const double r_max = (use_lane_boundaries ? lane_bounds_.max() : segment_bounds_.max()) + r0_;
   // Lane position is over the segment's road curve frame, so a change is
   // needed. That implies getting the path length s from p and translating the r
   // coordinate because of the offset.

--- a/src/maliput_multilane/lane.h
+++ b/src/maliput_multilane/lane.h
@@ -156,6 +156,11 @@ class Lane : public api::Lane {
 
   api::LanePositionResult DoToLanePosition(const api::InertialPosition& inertial_position) const override;
 
+  api::LanePositionResult DoToSegmentPosition(const api::InertialPosition& inertial_position) const override;
+
+  api::LanePositionResult InertialToLaneSegmentPositionBackend(const api::InertialPosition& inertial_position,
+                                                               bool use_lane_boundaries) const;
+
   const api::LaneId id_;
   const api::Segment* segment_{};
   const int index_{};

--- a/src/maliput_multilane/road_geometry.cc
+++ b/src/maliput_multilane/road_geometry.cc
@@ -48,11 +48,11 @@ api::RoadPositionResult FromLanePositionResult(const api::Lane* const lane, cons
   return {api::RoadPosition{lane, result.lane_position}, result.nearest_position, result.distance};
 }
 
-// Evaluates if the result of `lane->ToLanePosition()` using `inertial_position`
+// Evaluates if the result of `lane->ToSegmentPosition()` using `inertial_position`
 // provides a closer api::RoadPositionResult than `road_position_result`.
 //
 // _Closer_ means:
-// - When the distance result of `lane->ToLanePosition()` is smaller than
+// - When the distance result of `lane->ToSegmentPosition()` is smaller than
 //   `road_position_result.distance` by more than `linear_tolerance`.
 // - When distances are equal, if both positions fall within their
 //   respective lane's lane bounds or none do, the new r-coordinate
@@ -61,7 +61,7 @@ api::RoadPositionResult FromLanePositionResult(const api::Lane* const lane, cons
 //   `road_position_result.road_position.pos` doesn't.
 //
 // When any of the previous conditions is met, an api::RoadPositionResult
-// is returned using `lane`, and the results of calling `ToLanePosition()`
+// is returned using `lane`, and the results of calling `ToSegmentPosition()`
 // on it. Otherwise, it returns the original `road_position_result`.
 //
 // The following preconditions should be met:
@@ -73,7 +73,7 @@ const api::RoadPositionResult EvaluateRoadPositionResult(const api::InertialPosi
   MALIPUT_DEMAND(lane != nullptr);
 
   const api::RoadPositionResult new_road_position_result =
-      FromLanePositionResult(lane, lane->ToLanePosition(inertial_position));
+      FromLanePositionResult(lane, lane->ToSegmentPosition(inertial_position));
 
   const double delta = new_road_position_result.distance - road_position_result.distance;
   if (delta > linear_tolerance) {  // new_distance is bigger than *distance, so this LanePosition is discarded.
@@ -147,7 +147,7 @@ api::RoadPositionResult RoadGeometry::DoToRoadPosition(const api::InertialPositi
   // extends beyond only adjacent lanes.
   if (hint.has_value()) {
     MALIPUT_DEMAND(hint->lane != nullptr);
-    road_position_result = FromLanePositionResult(hint->lane, hint->lane->ToLanePosition(inertial_position));
+    road_position_result = FromLanePositionResult(hint->lane, hint->lane->ToSegmentPosition(inertial_position));
     if (road_position_result.distance != 0.) {
       // Loop through ongoing lanes at both ends of the current lane, to find
       // the position associated with the first found containing lane or the
@@ -169,7 +169,7 @@ api::RoadPositionResult RoadGeometry::DoToRoadPosition(const api::InertialPositi
     MALIPUT_DEMAND(junction(0)->num_segments() > 0);
     MALIPUT_DEMAND(junction(0)->segment(0)->num_lanes() > 0);
     const api::Lane* lane = this->junction(0)->segment(0)->lane(0);
-    road_position_result = FromLanePositionResult(lane, lane->ToLanePosition(inertial_position));
+    road_position_result = FromLanePositionResult(lane, lane->ToSegmentPosition(inertial_position));
     for (int i = 0; i < num_junctions(); ++i) {
       const api::Junction* junction = this->junction(i);
       for (int j = 0; j < junction->num_segments(); ++j) {


### PR DESCRIPTION
Related to https://github.com/maliput/maliput/issues/496

### Summary

Matches with https://github.com/maliput/maliput/pull/521

action-ros-ci-repos-override: https://gist.githubusercontent.com/francocipollone/b4f12ba16f95b45495362ae94202e810/raw/4d8ef8ec3fe272ca0619366ba2f389a934ca1aa0/maliput_multilane.repos