### PR TITLE
Implements interface for providing default parameters via plugin.

### DIFF
--- a/src/plugin/road_network.cc
+++ b/src/plugin/road_network.cc
@@ -98,12 +98,35 @@ std::unique_ptr<maliput::api::RoadNetwork> BuildRoadNetworkFromParams(
   }
 }
 
+// Returns a dictionary of default parameters for the multilane builder.
+// There are two builders that will be used depending on the value of the 'road_network_source' parameter, so
+// the default parameters for each builder are returned.
+//
+// When road_network_source is
+// - yaml: The maliput::multilane::BuildRoadNetwork builder is used.
+// - on_ramp_merge: The maliput::multilane::BuildOnRampMergeRoadNetwork builder is used.
+std::map<std::string, std::string> GetDefaultParametersForTheBuilders() {
+  MultilaneRoadCharacteristics default_values{};
+  return {
+      {"road_network_source", "yaml"},
+      {"yaml_file", ""},
+      {"lane_width", std::to_string(default_values.lane_width)},
+      {"left_shoulder", std::to_string(default_values.left_shoulder)},
+      {"right_shoulder", std::to_string(default_values.right_shoulder)},
+      {"lane_number", std::to_string(default_values.lane_number)},
+  };
+}
+
 // Implementation of a maliput::plugin::RoadNetworkLoader using multilane backend.
 class RoadNetworkLoader : public maliput::plugin::RoadNetworkLoader {
  public:
   std::unique_ptr<maliput::api::RoadNetwork> operator()(
       const std::map<std::string, std::string>& properties) const override {
     return BuildRoadNetworkFromParams(properties);
+  }
+
+  std::map<std::string, std::string> GetDefaultParameters() const override {
+    return GetDefaultParametersForTheBuilders();
   }
 };
 


### PR DESCRIPTION
# 🎉 New feature

Closes #78 

## Summary

`RoadNetworkPlugin::GetDefaultParameters` method is implemented so it can be obtained via plugin interface




Note that `maliput_multilane` has two different builders.
  - For building via yaml file
  - For building an on-ramp merge.

Usecase: Maliput viz application:

- Using `road_network_source`: yaml
![image](https://user-images.githubusercontent.com/53065142/206465461-77044a96-7005-406b-8160-94434ab40df0.png)

- Using `road_network_source`: on_ramp_merge
![image](https://user-images.githubusercontent.com/53065142/206465611-0aeb743c-f948-4952-8e84-97e2c44b4990.png)


## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

