### PR TITLE
Removes fmt as dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ project(maliput_multilane LANGUAGES C CXX VERSION 3.0.0)
 message(STATUS "\n\n====== Finding 3rd Party Packages ======\n")
 
 find_package(ament_cmake REQUIRED)
-find_package(fmt 6.1.2 EXACT REQUIRED)
 find_package(maliput REQUIRED)
 find_package(maliput_drake REQUIRED)
 find_package(yaml-cpp REQUIRED)
@@ -78,7 +77,6 @@ install(
 ament_export_include_directories(include)
 
 ament_export_dependencies(ament_cmake)
-ament_export_dependencies(fmt)
 ament_export_dependencies(maliput)
 ament_export_dependencies(maliput_drake)
 ament_export_dependencies(yaml-cpp)

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <doc_depend>ament_cmake_doxygen</doc_depend>
 
-  <depend>fmt</depend>
   <depend>maliput</depend>
   <depend>maliput_drake</depend>
   <depend>yaml-cpp</depend>

--- a/src/maliput_multilane_test_utilities/multilane_types_compare.cc
+++ b/src/maliput_multilane_test_utilities/multilane_types_compare.cc
@@ -31,11 +31,9 @@
 
 #include <cmath>
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <vector>
-
-#include <fmt/format.h>
-#include <fmt/ostream.h>
 
 namespace maliput {
 namespace multilane {
@@ -48,35 +46,39 @@ namespace test {
   double delta = std::abs(xy1.x() - xy2.x());
   if (delta > linear_tolerance) {
     fails = true;
-    error_message += fmt::format(
-        "EndpointXys are different at x coordinate. "
-        "xy1.x(): {} vs.xy2.x(): {}, diff = {}, linear tolerance = {}.\n",
-        xy1.x(), xy2.x(), delta, linear_tolerance);
+    std::stringstream ss;
+    ss << "EndpointXys are different at x coordinate.\n";
+    ss << "xy1.x(): " << xy1.x() << " vs. xy2.x(): " << xy2.x() << ", diff = " << delta
+       << ", linear tolerance = " << linear_tolerance << "\n";
+    error_message += ss.str();
   }
   delta = std::abs(xy1.y() - xy2.y());
   if (delta > linear_tolerance) {
     fails = true;
-    error_message += fmt::format(
-        "EndpointXys are different at y coordinate. "
-        "xy1.y(): {} vs.xy2.y(): {}, diff = {}, linear tolerance = {}.\n",
-        xy1.y(), xy2.y(), delta, linear_tolerance);
+    std::stringstream ss;
+    ss << "EndpointXys are different at y coordinate.\n";
+    ss << "xy1.y(): " << xy1.y() << " vs. xy2.y(): " << xy2.y() << ", diff = " << delta
+       << ", linear tolerance = " << linear_tolerance << "\n";
+    error_message += ss.str();
   }
   delta = std::abs(xy1.heading() - xy2.heading());
   if (delta > angular_tolerance) {
     fails = true;
-    error_message += fmt::format(
-        "EndpointXys are different at heading angle. "
-        "xy1.heading(): {} vs.xy2.heading(): {}, diff = {}, "
-        "angular tolerance = {}.\n",
-        xy1.heading(), xy2.heading(), delta, angular_tolerance);
+    std::stringstream ss;
+    ss << "EndpointXys are different at heading angle.\n";
+    ss << "xy1.heading(): " << xy1.heading() << " vs.xy2.heading(): " << xy2.heading() << ", diff = " << delta
+       << ", angular tolerance = " << angular_tolerance << "\n";
+    error_message += ss.str();
   }
   if (fails) {
     return ::testing::AssertionFailure() << error_message;
   }
-  return ::testing::AssertionSuccess() << fmt::format(
-             "xy1 =\n{}\nis approximately equal to xy2 =\n{}\n"
-             "linear tolerance = {}, angular tolerance = {}",
-             xy1, xy2, linear_tolerance, angular_tolerance);
+  std::stringstream ss;
+  ss << "xy1 =\n"
+     << xy1 << "\nis approximately equal to xy2 =\n"
+     << xy2 << "\n"
+     << "linear tolerance = " << linear_tolerance << ", angular tolerance = " << angular_tolerance;
+  return ::testing::AssertionSuccess() << ss.str();
 }
 
 ::testing::AssertionResult IsEndpointZClose(const EndpointZ& z1, const EndpointZ& z2, double linear_tolerance,
@@ -86,35 +88,39 @@ namespace test {
   double delta = std::abs(z1.z() - z2.z());
   if (delta > linear_tolerance) {
     fails = true;
-    error_message += fmt::format(
-        "EndpointZ are different at z coordinate. z1.z(): {} vs z2.z(): {}"
-        ", diff = {}, linear tolerance = {}\n",
-        z1.z(), z2.z(), delta, linear_tolerance);
+    std::stringstream ss;
+    ss << "EndpointZ are different at z coordinate. ";
+    ss << "z1.z(): " << z1.z() << " vs z2.z(): " << z2.z() << ", diff = " << delta
+       << ", linear tolerance = " << linear_tolerance << "\n";
+    error_message += ss.str();
   }
   delta = std::abs(z1.z_dot() - z2.z_dot());
   if (delta > linear_tolerance) {
     fails = true;
-    error_message += fmt::format(
-        "EndpointZ are different at z_dot coordinate. z1.z_dot(): {} vs "
-        "z2.z_dot(): {}, diff = {}, linear tolerance = {}\n",
-        z1.z_dot(), z2.z_dot(), delta, linear_tolerance);
+    std::stringstream ss;
+    ss << "EndpointZ are different at z_dot coordinate. ";
+    ss << "z1.z_dot(): " << z1.z_dot() << " vs z2.z_dot(): " << z2.z_dot() << ", diff = " << delta
+       << ", linear tolerance = " << linear_tolerance << "\n";
+    error_message += ss.str();
   }
   delta = std::abs(z1.theta() - z2.theta());
   if (delta > angular_tolerance) {
     fails = true;
-    error_message += fmt::format(
-        "EndpointZ are different at theta angle. z1.theta(): {} vs "
-        "z2.theta(): {}, diff = {}, angular tolerance = {}\n",
-        z1.theta(), z2.theta(), delta, angular_tolerance);
+    std::stringstream ss;
+    ss << "EndpointZ are different at theta angle. ";
+    ss << "z1.theta(): " << z1.theta() << " vs z2.theta(): " << z2.theta() << ", diff = " << delta
+       << ", angular tolerance = " << angular_tolerance << "\n";
+    error_message += ss.str();
   }
   if (z1.theta_dot().has_value() && z2.theta_dot().has_value()) {
     delta = std::abs(*z1.theta_dot() - *z2.theta_dot());
     if (delta > angular_tolerance) {
       fails = true;
-      error_message += fmt::format(
-          "EndpointZ are different at theta_dot. z1.theta_dot(): {} vs "
-          "z2.theta_dot(): {}, diff = {}, angular tolerance = {}\n",
-          *z1.theta_dot(), *z2.theta_dot(), delta, angular_tolerance);
+      std::stringstream ss;
+      ss << "EndpointZ are different at theta_dot. ";
+      ss << "z1.theta_dot(): " << *z1.theta_dot() << " vs z2.theta_dot(): " << *z2.theta_dot() << ", diff = " << delta
+         << ", angular tolerance = " << angular_tolerance << "\n";
+      error_message += ss.str();
     }
   } else if (z1.theta_dot().has_value() && !z2.theta_dot().has_value()) {
     fails = true;
@@ -132,10 +138,12 @@ namespace test {
   if (fails) {
     return ::testing::AssertionFailure() << error_message;
   }
-  return ::testing::AssertionSuccess() << fmt::format(
-             "z1 =\n{}\nis approximately equal to z2 =\n{}\n"
-             "linear tolerance = {}, angular tolerance = {}",
-             z1, z2, linear_tolerance, angular_tolerance);
+  std::stringstream ss;
+  ss << "z1 =\n"
+     << z1 << "\nis approximately equal to z2 =\n"
+     << z2 << "\n"
+     << "linear tolerance = " << linear_tolerance << ", angular tolerance = " << angular_tolerance;
+  return ::testing::AssertionSuccess() << ss.str();
 }
 
 ::testing::AssertionResult IsEndpointClose(const Endpoint& p1, const Endpoint& p2, double linear_tolerance,
@@ -148,22 +156,24 @@ namespace test {
   if (!endpoint_xy_comparison) {
     fails = true;
     error_message +=
-        fmt::format("Endpoint p1 is different from p2 at EndpointXy. [{}]\n", endpoint_xy_comparison.message());
+        "Endpoint p1 is different from p2 at EndpointXy. [" + std::string(endpoint_xy_comparison.message()) + "]\n";
   }
   const ::testing::AssertionResult endpoint_z_comparison =
       IsEndpointZClose(p1.z(), p2.z(), linear_tolerance, angular_tolerance);
   if (!endpoint_z_comparison) {
     fails = true;
     error_message +=
-        fmt::format("Endpoint p1 is different from p2 at EndpointZ. [{}]\n", endpoint_z_comparison.message());
+        "Endpoint p1 is different from p2 at EndpointZ. [" + std::string(endpoint_z_comparison.message()) + "]\n";
   }
   if (fails) {
     return ::testing::AssertionFailure() << error_message;
   }
-  return ::testing::AssertionSuccess() << fmt::format(
-             "p1 =\n{}\nis approximately equal to p2 =\n{}\n"
-             "linear tolerance = {}, angular tolerance = {}",
-             p1, p2, linear_tolerance, angular_tolerance);
+  std::stringstream ss;
+  ss << "p1 =\n"
+     << p1 << "\nis approximately equal to p2 =\n"
+     << p2 << "\n"
+     << "linear tolerance = " << linear_tolerance << ", angular tolerance = " << angular_tolerance;
+  return ::testing::AssertionSuccess() << ss.str();
 }
 
 ::testing::AssertionResult IsArcOffsetClose(const ArcOffset& arc_offset1, const ArcOffset& arc_offset2,
@@ -173,27 +183,30 @@ namespace test {
   double delta = std::abs(arc_offset1.radius() - arc_offset2.radius());
   if (delta > linear_tolerance) {
     fails = true;
-    error_message += fmt::format(
-        "ArcOffset are different at radius. arc_offset1.radius(): {} vs. "
-        "arc_offset2.radius(): {}, diff = {}, tolerance = {}\n",
-        arc_offset1.radius(), arc_offset2.radius(), delta, linear_tolerance);
+    std::stringstream ss;
+    ss << "ArcOffset are different at radius. ";
+    ss << "arc_offset1.radius(): " << arc_offset1.radius() << " vs. arc_offset2.radius(): " << arc_offset2.radius()
+       << ", diff = " << delta << ", tolerance = " << linear_tolerance << "\n";
+    error_message += ss.str();
   }
   delta = std::abs(arc_offset1.d_theta() - arc_offset2.d_theta());
   if (delta > angular_tolerance) {
     fails = true;
-    error_message += fmt::format(
-        "ArcOffset are different at d_theta. arc_offset1.d_theta(): {} vs. "
-        "arc_offset2.d_theta(): {}, diff = {}, tolerance = {}\n",
-        arc_offset1.d_theta(), arc_offset2.d_theta(), delta, angular_tolerance);
+    std::stringstream ss;
+    ss << "ArcOffset are different at d_theta. ";
+    ss << "arc_offset1.d_theta(): " << arc_offset1.d_theta() << " vs. arc_offset2.d_theta(): " << arc_offset2.d_theta()
+       << ", diff = " << delta << ", tolerance = " << angular_tolerance << "\n";
+    error_message += ss.str();
   }
   if (fails) {
     return ::testing::AssertionFailure() << error_message;
   }
-  return ::testing::AssertionSuccess() << fmt::format(
-             "arc_offset1 =\n{}\nis approximately equal to "
-             "arc_offset2 =\n{}\nwith linear tolerance = {}\n"
-             "and angular tolerance ={}",
-             arc_offset1, arc_offset2, linear_tolerance, angular_tolerance);
+  std::stringstream ss;
+  ss << "arc_offset1 =\n"
+     << arc_offset1 << "\nis approximately equal to arc_offset2 =\n"
+     << arc_offset2 << "\n"
+     << "linear tolerance = " << linear_tolerance << "\nand angular tolerance = " << angular_tolerance;
+  return ::testing::AssertionSuccess() << ss.str();
 }
 
 Matcher<const api::HBounds&> Matches(const api::HBounds& elevation_bounds, double tolerance) {

--- a/test/maliput_multilane/multilane_connection_test.cc
+++ b/test/maliput_multilane/multilane_connection_test.cc
@@ -33,8 +33,8 @@
 
 #include <cmath>
 #include <ostream>
+#include <sstream>
 
-#include <fmt/format.h>
 #include <gtest/gtest.h>
 #include <maliput/math/vector.h>
 #include <maliput/test_utilities/maliput_math_compare.h>
@@ -72,20 +72,20 @@ using maliput::math::test::CompareVectors;
     const double delta = std::abs(coefficients1[i] - coefficients2[i]);
     if (delta > tolerance) {
       fails = true;
-      error_message += fmt::format(
-          "Cubic polynomials are different at {0} coefficient. "
-          "cubic1.{0}(): {1} vs. cubic2.{0}(): {2}, diff = {3}, "
-          "tolerance = {4}\n",
-          coefficient_strs[i], coefficients1[i], coefficients2[i], delta, tolerance);
+      std::stringstream ss;
+      ss << "Cubic polynomials are different at " << coefficient_strs[i] << " coefficient. "
+         << "cubic1." << coefficient_strs[i] << "(): " << std::to_string(coefficients1[i]) << " vs. cubic2."
+         << coefficient_strs[i] << "(): " << std::to_string(coefficients2[i]) << ", diff = " << std::to_string(delta)
+         << ", tolerance = " << std::to_string(tolerance) << "\n";
+      error_message += ss.str();
     }
   }
   if (fails) {
     return ::testing::AssertionFailure() << error_message;
   }
-  return ::testing::AssertionSuccess() << fmt::format(
-             "cubic1 =\n{}\nis approximately equal to cubic2 =\n{}"
-             "\ntolerance = {}",
-             cubic1, cubic2, tolerance);
+  std::stringstream ss;
+  ss << "cubic1 =\n" << cubic1 << "\nis approximately equal to cubic2 =\n" << cubic2 << "\ntolerance = " << tolerance;
+  return ::testing::AssertionSuccess() << ss.str();
 }
 
 }  // namespace test
@@ -388,11 +388,10 @@ struct EndpointZTestParameters {
 // no stream insertion operator overload is present) and trigger Valgrind
 // errors.
 std::ostream& operator<<(std::ostream& stream, const EndpointZTestParameters& endpoint_z_test_param) {
-  return stream << fmt::format(
-             "EndpointZTestParameters( start_z: ({}), "
-             "end_z: ({}), r0: {}, num_lanes: {})",
-             endpoint_z_test_param.start_z, endpoint_z_test_param.end_z, endpoint_z_test_param.r0,
-             endpoint_z_test_param.num_lanes);
+  stream << "EndpointZTestParameters( start_z: (" << endpoint_z_test_param.start_z << "), "
+         << "end_z: (" << endpoint_z_test_param.end_z << "), r0: " << endpoint_z_test_param.r0
+         << ", num_lanes: " << endpoint_z_test_param.num_lanes << ")";
+  return stream;
 }
 
 // Groups common test constants as well as each test case parameters.

--- a/test/maliput_multilane/multilane_road_curve_accuracy_test.cc
+++ b/test/maliput_multilane/multilane_road_curve_accuracy_test.cc
@@ -36,7 +36,6 @@
 #include <tuple>
 #include <utility>
 
-#include <fmt/format.h>
 #include <gtest/gtest.h>
 #include <maliput/common/maliput_throw.h>
 #include <maliput/math/vector.h>
@@ -234,11 +233,11 @@ TEST_P(RoadCurveAccuracyTest, PathLengthComputationAccuracy) {
       const double relative_error = (k_order_s_approximation != 0.0)
                                         ? (s_from_p_at_r(p) - k_order_s_approximation) / k_order_s_approximation
                                         : s_from_p_at_r(p);
-      EXPECT_LE(relative_error, kTolerance) << fmt::format(
-          "Path length estimation with a tolerance of {} "
-          "m failed at p = {}, r = {} m, h = {} m with "
-          "{} for elevation and {} for superelevation",
-          road_curve->linear_tolerance(), p, r, kH, road_curve->elevation(), road_curve->superelevation());
+      EXPECT_LE(relative_error, kTolerance)
+          << "Path length estimation with a tolerance of " << std::to_string(road_curve->linear_tolerance()) << " "
+          << "m failed at p = " << std::to_string(p) << ", r = " << std::to_string(r)
+          << " m, h = " << std::to_string(kH) << " m with " << road_curve->elevation() << " for elevation and "
+          << road_curve->superelevation() << " for superelevation";
     }
   }
 }


### PR DESCRIPTION
# 🎉 New feature

## Summary
 - replace `fmt::format` appearances by custom implementation.
 - removes fmt dependency.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)
