### PR TITLE
Removes maliput_drake dependency.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -7,7 +7,3 @@ repositories:
     type: git
     url: https://github.com/maliput/maliput
     version: main
-  maliput_drake:
-    type: git
-    url: https://github.com/maliput/maliput_drake
-    version: main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@ message(STATUS "\n\n====== Finding 3rd Party Packages ======\n")
 
 find_package(ament_cmake REQUIRED)
 find_package(maliput REQUIRED)
-find_package(maliput_drake REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
 ##############################################################################
@@ -78,7 +77,6 @@ ament_export_include_directories(include)
 
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(maliput)
-ament_export_dependencies(maliput_drake)
 ament_export_dependencies(yaml-cpp)
 ament_export_targets(${PROJECT_NAME}-targets HAS_LIBRARY_TARGET)
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,6 @@
   <doc_depend>ament_cmake_doxygen</doc_depend>
 
   <depend>maliput</depend>
-  <depend>maliput_drake</depend>
   <depend>yaml-cpp</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/src/maliput_multilane/CMakeLists.txt
+++ b/src/maliput_multilane/CMakeLists.txt
@@ -39,15 +39,14 @@ target_link_libraries(maliput_multilane
   PUBLIC
     maliput::api
     maliput::base
+    maliput::drake_systems_analysis
     maliput::geometry_base
     maliput::common
     maliput::math
-    maliput_drake::analysis
   PRIVATE
-    maliput_drake::common
-    maliput_drake::framework
-    maliput_drake::math
-    maliput_drake::trajectories
+    maliput::drake_common
+    maliput::drake_common_trajectories
+    maliput::drake_systems_framework
     yaml-cpp
 )
 

--- a/src/maliput_multilane/arc_road_curve.cc
+++ b/src/maliput_multilane/arc_road_curve.cc
@@ -33,7 +33,6 @@
 #include <limits>
 
 #include <maliput/common/maliput_abort.h>
-#include <maliput/drake/math/saturate.h>
 
 namespace maliput {
 namespace multilane {
@@ -129,13 +128,13 @@ math::Vector3 ArcRoadCurve::ToCurveFrame(const math::Vector3& geo_coordinate, do
   // Compute r (its direction depends on the direction of the +s-coordinate)
   const double r_unsaturated = (d_theta_ >= 0.) ? radius_ - v.norm() : v.norm() - radius_;
   // Saturate r within segment bounds.
-  const double r = maliput::drake::math::saturate(r_unsaturated, r_min, r_max);
+  const double r = std::clamp(r_unsaturated, r_min, r_max);
 
   // Calculate the (uniform) road elevation.
   // N.B. h is the geo z-coordinate referenced against the lane elevation (whose
   // `a` coefficient is normalized by lane length).
   const double h_unsaturated = geo_coordinate.z() - elevation().a() * l_max();
-  const double h = maliput::drake::math::saturate(h_unsaturated, height_bounds.min(), height_bounds.max());
+  const double h = std::clamp(h_unsaturated, height_bounds.min(), height_bounds.max());
   return math::Vector3(p, r, h);
 }
 

--- a/src/maliput_multilane/line_road_curve.cc
+++ b/src/maliput_multilane/line_road_curve.cc
@@ -29,7 +29,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "maliput_multilane/line_road_curve.h"
 
-#include <maliput/drake/math/saturate.h>
+#include <algorithm>
 
 namespace maliput {
 namespace multilane {
@@ -59,13 +59,13 @@ math::Vector3 LineRoadCurve::ToCurveFrame(const math::Vector3& geo_coordinate, d
 
   // Compute the distance from `q` to the start of the lane.
   const double p_unsaturated = lane_origin_to_q.dot(s_unit_vector) / l_max();
-  const double p = maliput::drake::math::saturate(p_unsaturated, 0., 1.);
+  const double p = std::clamp(p_unsaturated, 0., 1.);
   const double r_unsaturated = lane_origin_to_q.dot(r_unit_vector);
-  const double r = maliput::drake::math::saturate(r_unsaturated, r_min, r_max);
+  const double r = std::clamp(r_unsaturated, r_min, r_max);
   // N.B. h is the geo z-coordinate referenced against the lane elevation (whose
   // `a` coefficient is normalized by lane length).
   const double h_unsaturated = geo_coordinate.z() - elevation().a() * l_max();
-  const double h = maliput::drake::math::saturate(h_unsaturated, height_bounds.min(), height_bounds.max());
+  const double h = std::clamp(h_unsaturated, height_bounds.min(), height_bounds.max());
   return math::Vector3(p, r, h);
 }
 

--- a/src/maliput_multilane_test_utilities/CMakeLists.txt
+++ b/src/maliput_multilane_test_utilities/CMakeLists.txt
@@ -33,12 +33,12 @@ target_link_libraries(test_utilities
     maliput::math
     maliput_multilane
   PRIVATE
-    maliput_drake::analysis
-    maliput_drake::common
-    maliput_drake::framework
-    maliput_drake::math
-    maliput_drake::trajectories
+    maliput::drake_common
+    maliput::drake_common_trajectories
+    maliput::drake_systems_analysis
+    maliput::drake_systems_framework
 )
+
 
 install(
   TARGETS test_utilities

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,8 +18,8 @@ macro(add_dependencies_to_test target)
       target_link_libraries(${target}
           maliput::api
           maliput::common
+          maliput::drake_common
           maliput::math
-          maliput_drake::common
           maliput_multilane::maliput_multilane
           maliput_multilane::test_utilities
       )

--- a/test/plugin/CMakeLists.txt
+++ b/test/plugin/CMakeLists.txt
@@ -30,14 +30,13 @@ macro(add_dependencies_to_test target)
           maliput_multilane::maliput_multilane
           maliput::common
           maliput::plugin
-          # maliput_drake is required because we include maliput_multilane/road_geometry.h to verify
+          # maliput::drake is required because we include maliput_multilane/road_geometry.h to verify
           # the type of the loaded plugin. That requires other types to be imported as well which
           # boils down up to road_curve.h.
-          maliput_drake::analysis
-          maliput_drake::common
-          maliput_drake::framework
-          maliput_drake::math
-          maliput_drake::trajectories
+          maliput::drake_common
+          maliput::drake_common_trajectories
+          maliput::drake_systems_analysis
+          maliput::drake_systems_framework
       )
     endif()
 endmacro()


### PR DESCRIPTION
# 🎉 New feature

## Summary
Context: maliput_drake has been moved into maliput
 - This PR, removes the maliput_drake dependency and points to maliput::drake

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

