### PR TITLE
Removes maliput::test_utilities dependency.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: gcc
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -10,6 +12,11 @@ on:
 env:
   PACKAGE_NAME: maliput_multilane
   ROS_DISTRO: foxy
+
+# Cancel previously running PR jobs
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   compile_and_test:

--- a/include/maliput_multilane_test_utilities/multilane_types_compare.h
+++ b/include/maliput_multilane_test_utilities/multilane_types_compare.h
@@ -31,7 +31,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <maliput/test_utilities/maliput_types_compare.h>
+#include <maliput/api/compare.h>
 
 #include "maliput_multilane/builder.h"
 #include "maliput_multilane/connection.h"
@@ -124,7 +124,7 @@ class HBoundsMatcher : public MatcherInterface<const api::HBounds&> {
       : elevation_bounds_(elevation_bounds), tolerance_(tolerance) {}
 
   bool MatchAndExplain(const api::HBounds& other, MatchResultListener*) const override {
-    return api::test::IsHBoundsClose(elevation_bounds_, other, tolerance_);
+    return !api::IsHBoundsClose(elevation_bounds_, other, tolerance_).message.has_value();
   }
 
   void DescribeTo(std::ostream* os) const override {

--- a/src/maliput_multilane_test_utilities/CMakeLists.txt
+++ b/src/maliput_multilane_test_utilities/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(test_utilities
   PUBLIC
     maliput::api
     maliput::common
-    maliput::test_utilities
     maliput::math
     maliput_multilane
   PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ macro(add_dependencies_to_test target)
       target_include_directories(${target}
         PRIVATE
           ${PROJECT_SOURCE_DIR}/include
+          ${PROJECT_SOURCE_DIR}/test
       )
 
       set(MULTILANE_RESOURCE_ROOT ${PROJECT_SOURCE_DIR}/resources/)

--- a/test/assert_compare.h
+++ b/test/assert_compare.h
@@ -1,0 +1,48 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Woven by Toyota. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <gtest/gtest.h>
+#include <maliput/common/compare.h>
+
+namespace maliput {
+namespace multilane {
+namespace test {
+
+template <typename T>
+::testing::AssertionResult AssertCompare(const maliput::common::ComparisonResult<T>& res) {
+  if (!res.message.has_value()) {
+    return ::testing::AssertionSuccess();
+  }
+  return ::testing::AssertionFailure() << res.message.value();
+}
+
+}  // namespace test
+}  // namespace multilane
+}  // namespace maliput

--- a/test/maliput_multilane/multilane_arc_road_curve_test.cc
+++ b/test/maliput_multilane/multilane_arc_road_curve_test.cc
@@ -34,13 +34,16 @@
 #include <gtest/gtest.h>
 #include <maliput/api/lane_data.h>
 #include <maliput/common/assertion_error.h>
-#include <maliput/test_utilities/maliput_math_compare.h>
+#include <maliput/math/compare.h>
+
+#include "assert_compare.h"
 
 namespace maliput {
 namespace multilane {
 namespace {
 
-using maliput::math::test::CompareVectors;
+using maliput::math::CompareVectors;
+using maliput::multilane::test::AssertCompare;
 
 class MultilaneArcRoadCurveTest : public ::testing::Test {
  protected:
@@ -116,25 +119,27 @@ TEST_F(MultilaneArcRoadCurveTest, ArcGeometryTest) {
   EXPECT_THROW(p_from_s_at_r(2. * offset_line_length), maliput::common::assertion_error);
 
   // Checks the evaluation of xy at different values over the reference curve.
-  EXPECT_TRUE(CompareVectors(
-      dut.xy_of_p(0.0), kCenter + math::Vector2(kRadius * std::cos(kTheta0), kRadius * std::sin(kTheta0)), kVeryExact));
-  EXPECT_TRUE(CompareVectors(
+  EXPECT_TRUE(AssertCompare(
+      CompareVectors(dut.xy_of_p(0.0),
+                     kCenter + math::Vector2(kRadius * std::cos(kTheta0), kRadius * std::sin(kTheta0)), kVeryExact)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(
       dut.xy_of_p(0.5),
       kCenter + math::Vector2(kRadius * std::cos(kTheta0 + kDTheta * 0.5), kRadius * std::sin(kTheta0 + kDTheta * 0.5)),
-      kVeryExact));
-  EXPECT_TRUE(CompareVectors(
-      dut.xy_of_p(1.0), kCenter + math::Vector2(kRadius * std::cos(kTheta1), kRadius * std::sin(kTheta1)), kVeryExact));
+      kVeryExact)));
+  EXPECT_TRUE(AssertCompare(
+      CompareVectors(dut.xy_of_p(1.0),
+                     kCenter + math::Vector2(kRadius * std::cos(kTheta1), kRadius * std::sin(kTheta1)), kVeryExact)));
   // Checks the derivative of xy at different values over the reference curve.
-  EXPECT_TRUE(CompareVectors(
+  EXPECT_TRUE(AssertCompare(CompareVectors(
       dut.xy_dot_of_p(0.0),
-      math::Vector2(-kRadius * std::sin(kTheta0) * kDTheta, kRadius * std::cos(kTheta0) * kDTheta), kVeryExact));
-  EXPECT_TRUE(CompareVectors(dut.xy_dot_of_p(0.5),
-                             math::Vector2(-kRadius * std::sin(kTheta0 + 0.5 * kDTheta) * kDTheta,
-                                           kRadius * std::cos(kTheta0 + 0.5 * kDTheta) * kDTheta),
-                             kVeryExact));
-  EXPECT_TRUE(CompareVectors(
+      math::Vector2(-kRadius * std::sin(kTheta0) * kDTheta, kRadius * std::cos(kTheta0) * kDTheta), kVeryExact)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(dut.xy_dot_of_p(0.5),
+                                           math::Vector2(-kRadius * std::sin(kTheta0 + 0.5 * kDTheta) * kDTheta,
+                                                         kRadius * std::cos(kTheta0 + 0.5 * kDTheta) * kDTheta),
+                                           kVeryExact)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(
       dut.xy_dot_of_p(1.0),
-      math::Vector2(-kRadius * std::sin(kTheta1) * kDTheta, kRadius * std::cos(kTheta1) * kDTheta), kVeryExact));
+      math::Vector2(-kRadius * std::sin(kTheta1) * kDTheta, kRadius * std::cos(kTheta1) * kDTheta), kVeryExact)));
   // Checks the heading at different values.
   EXPECT_NEAR(dut.heading_of_p(0.0), kTheta0 + M_PI / 2.0, kVeryExact);
   EXPECT_NEAR(dut.heading_of_p(0.5), kTheta0 + kDTheta / 2.0 + M_PI / 2.0, kVeryExact);
@@ -206,31 +211,33 @@ TEST_F(MultilaneArcRoadCurveTest, ToCurveFrameTest) {
   const ArcRoadCurve dut(kCenter, kRadius, kTheta0, kDTheta, zp, zp, kLinearTolerance, kScaleLength,
                          kComputationPolicy);
   // Checks points over the composed curve.
-  EXPECT_TRUE(CompareVectors(dut.ToCurveFrame(math::Vector3(kCenter[0] + kRadius * std::cos(kTheta0),
-                                                            kCenter[1] + kRadius * std::sin(kTheta0), 0.0),
-                                              kRMin, kRMax, height_bounds),
-                             math::Vector3(0.0, 0.0, 0.0), kVeryExact));
   EXPECT_TRUE(
+      AssertCompare(CompareVectors(dut.ToCurveFrame(math::Vector3(kCenter[0] + kRadius * std::cos(kTheta0),
+                                                                  kCenter[1] + kRadius * std::sin(kTheta0), 0.0),
+                                                    kRMin, kRMax, height_bounds),
+                                   math::Vector3(0.0, 0.0, 0.0), kVeryExact)));
+  EXPECT_TRUE(AssertCompare(
       CompareVectors(dut.ToCurveFrame(math::Vector3(kCenter[0] + kRadius * std::cos(kTheta0 + kDTheta / 2.0),
                                                     kCenter[1] + kRadius * std::sin(kTheta0 + kDTheta / 2.0), 0.0),
                                       kRMin, kRMax, height_bounds),
-                     math::Vector3(0.5, 0.0, 0.0), kVeryExact));
-  EXPECT_TRUE(CompareVectors(dut.ToCurveFrame(math::Vector3(kCenter[0] + kRadius * std::cos(kTheta1),
-                                                            kCenter[1] + kRadius * std::sin(kTheta1), 0.0),
-                                              kRMin, kRMax, height_bounds),
-                             math::Vector3(1., 0.0, 0.0), kVeryExact));
-  // Checks with lateral and vertical deviations.
+                     math::Vector3(0.5, 0.0, 0.0), kVeryExact)));
   EXPECT_TRUE(
+      AssertCompare(CompareVectors(dut.ToCurveFrame(math::Vector3(kCenter[0] + kRadius * std::cos(kTheta1),
+                                                                  kCenter[1] + kRadius * std::sin(kTheta1), 0.0),
+                                                    kRMin, kRMax, height_bounds),
+                                   math::Vector3(1., 0.0, 0.0), kVeryExact)));
+  // Checks with lateral and vertical deviations.
+  EXPECT_TRUE(AssertCompare(
       CompareVectors(dut.ToCurveFrame(math::Vector3(kCenter[0] + (kRadius + 1.0) * std::cos(kTheta0 + M_PI / 8.0),
                                                     kCenter[1] + (kRadius + 1.0) * std::sin(kTheta0 + M_PI / 8.0), 6.0),
                                       kRMin, kRMax, height_bounds),
-                     math::Vector3(0.25, -1.0, 6.0), kVeryExact));
-  EXPECT_TRUE(CompareVectors(
+                     math::Vector3(0.25, -1.0, 6.0), kVeryExact)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(
       dut.ToCurveFrame(
           math::Vector3(kCenter[0] + (kRadius - 2.0) * std::cos(kTheta0 + kDTheta / 2.0 + M_PI / 8.0),
                         kCenter[1] + (kRadius - 2.0) * std::sin(kTheta0 + kDTheta / 2.0 + M_PI / 8.0), 3.0),
           kRMin, kRMax, height_bounds),
-      math::Vector3(0.75, 2.0, 3.0), kVeryExact));
+      math::Vector3(0.75, 2.0, 3.0), kVeryExact)));
 }
 
 // Checks that l_max(), p_from_s() and s_from_p() with constant
@@ -300,7 +307,7 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunction) {
         const double angle = kTheta0 + kDTheta * p;
         const math::Vector3 geo_position = kGeoCenter + kRadius * math::Vector3(std::cos(angle), std::sin(angle), 0.) +
                                            flat_rotation.apply({0., r, h});
-        EXPECT_TRUE(CompareVectors(flat_dut.W_of_prh(p, r, h), geo_position, kVeryExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(flat_dut.W_of_prh(p, r, h), geo_position, kVeryExact)));
       }
     }
   }
@@ -322,7 +329,7 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunction) {
         const double angle = kTheta0 + kDTheta * p;
         const math::Vector3 geo_position = kGeoCenter + kRadius * math::Vector3(std::cos(angle), std::sin(angle), 0.) +
                                            linear_elevation.f_p(p) * z_vector + elevated_rotation.apply({0., r, h});
-        EXPECT_TRUE(CompareVectors(elevated_dut.W_of_prh(p, r, h), geo_position, kVeryExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(elevated_dut.W_of_prh(p, r, h), geo_position, kVeryExact)));
       }
     }
   }
@@ -339,7 +346,7 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunction) {
         const double angle = kTheta0 + kDTheta * p;
         const math::Vector3 geo_position = kGeoCenter + kRadius * math::Vector3(std::cos(angle), std::sin(angle), 0.) +
                                            superelevated_rotation.apply({0., r, h});
-        EXPECT_TRUE(CompareVectors(superelevated_dut.W_of_prh(p, r, h), geo_position, kVeryExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(superelevated_dut.W_of_prh(p, r, h), geo_position, kVeryExact)));
       }
     }
   }
@@ -379,9 +386,9 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunctionDerivative) {
         const double g_prime = flat_dut.elevation().f_dot_p(p);
         const math::Vector3 w_prime = flat_dut.W_prime_of_prh(p, r, h, rotation, g_prime);
         const math::Vector3 numeric_w_prime = numeric_w_prime_of_prh(flat_dut, p, r, h);
-        EXPECT_TRUE(CompareVectors(w_prime, numeric_w_prime, kQuiteExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(w_prime, numeric_w_prime, kQuiteExact)));
         const math::Vector3 s_hat = flat_dut.s_hat_of_prh(p, r, h, rotation, g_prime);
-        EXPECT_TRUE(CompareVectors(w_prime.normalized(), s_hat, kVeryExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(w_prime.normalized(), s_hat, kVeryExact)));
       }
     }
   }
@@ -400,9 +407,9 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunctionDerivative) {
         const double g_prime = elevated_dut.elevation().f_dot_p(p);
         const math::Vector3 w_prime = elevated_dut.W_prime_of_prh(p, r, h, rotation, g_prime);
         const math::Vector3 numeric_w_prime = numeric_w_prime_of_prh(elevated_dut, p, r, h);
-        EXPECT_TRUE(CompareVectors(w_prime, numeric_w_prime, kQuiteExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(w_prime, numeric_w_prime, kQuiteExact)));
         const math::Vector3 s_hat = elevated_dut.s_hat_of_prh(p, r, h, rotation, g_prime);
-        EXPECT_TRUE(CompareVectors(w_prime.normalized(), s_hat, kVeryExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(w_prime.normalized(), s_hat, kVeryExact)));
       }
     }
   }
@@ -420,9 +427,9 @@ TEST_F(MultilaneArcRoadCurveTest, WorldFunctionDerivative) {
         const double g_prime = superelevated_dut.elevation().f_dot_p(p);
         const math::Vector3 w_prime = superelevated_dut.W_prime_of_prh(p, r, h, rotation, g_prime);
         const math::Vector3 numeric_w_prime = numeric_w_prime_of_prh(superelevated_dut, p, r, h);
-        EXPECT_TRUE(CompareVectors(w_prime, numeric_w_prime, kQuiteExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(w_prime, numeric_w_prime, kQuiteExact)));
         const math::Vector3 s_hat = superelevated_dut.s_hat_of_prh(p, r, h, rotation, g_prime);
-        EXPECT_TRUE(CompareVectors(w_prime.normalized(), s_hat, kVeryExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(w_prime.normalized(), s_hat, kVeryExact)));
       }
     }
   }
@@ -453,28 +460,31 @@ TEST_F(MultilaneArcRoadCurveTest, ReferenceCurveRotation) {
     EXPECT_NEAR(rotation.pitch(), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), 3. * M_PI / 4., kVeryExact);
     math::Vector3 r_hat = flat_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareVectors(r_hat, math::Vector3(-0.707106781186548, -0.707106781186548, 0.), kVeryExact));
+    EXPECT_TRUE(
+        AssertCompare(CompareVectors(r_hat, math::Vector3(-0.707106781186548, -0.707106781186548, 0.), kVeryExact)));
 
     rotation = flat_dut.Rabg_of_p(0.5);
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(rotation.pitch(), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -M_PI, kVeryExact);
     r_hat = flat_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareVectors(r_hat, math::Vector3(0., -1., 0.), kVeryExact));
+    EXPECT_TRUE(AssertCompare(CompareVectors(r_hat, math::Vector3(0., -1., 0.), kVeryExact)));
 
     rotation = flat_dut.Rabg_of_p(0.75);
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(rotation.pitch(), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -7. * M_PI / 8., kVeryExact);
     r_hat = flat_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareVectors(r_hat, math::Vector3(0.382683432365090, -0.923879532511287, 0.), kVeryExact));
+    EXPECT_TRUE(
+        AssertCompare(CompareVectors(r_hat, math::Vector3(0.382683432365090, -0.923879532511287, 0.), kVeryExact)));
 
     rotation = flat_dut.Rabg_of_p(1.);
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(rotation.pitch(), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -3. * M_PI / 4., kVeryExact);
     r_hat = flat_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareVectors(r_hat, math::Vector3(0.707106781186548, -0.707106781186548, 0.), kVeryExact));
+    EXPECT_TRUE(
+        AssertCompare(CompareVectors(r_hat, math::Vector3(0.707106781186548, -0.707106781186548, 0.), kVeryExact)));
   }
 
   // Checks for a linearly elevated curve.
@@ -493,28 +503,31 @@ TEST_F(MultilaneArcRoadCurveTest, ReferenceCurveRotation) {
     EXPECT_NEAR(wrap(rotation.pitch()), kElevationPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), 3. * M_PI / 4., kVeryExact);
     math::Vector3 r_hat = elevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareVectors(r_hat, math::Vector3(-0.707106781186548, -0.707106781186548, 0.), kVeryExact));
+    EXPECT_TRUE(
+        AssertCompare(CompareVectors(r_hat, math::Vector3(-0.707106781186548, -0.707106781186548, 0.), kVeryExact)));
 
     rotation = elevated_dut.Rabg_of_p(0.5);
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kElevationPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -M_PI, kVeryExact);
     r_hat = elevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareVectors(r_hat, math::Vector3(0., -1., 0.), kVeryExact));
+    EXPECT_TRUE(AssertCompare(CompareVectors(r_hat, math::Vector3(0., -1., 0.), kVeryExact)));
 
     rotation = elevated_dut.Rabg_of_p(0.75);
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kElevationPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -7. * M_PI / 8., kVeryExact);
     r_hat = elevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareVectors(r_hat, math::Vector3(0.382683432365090, -0.923879532511287, 0.), kVeryExact));
+    EXPECT_TRUE(
+        AssertCompare(CompareVectors(r_hat, math::Vector3(0.382683432365090, -0.923879532511287, 0.), kVeryExact)));
 
     rotation = elevated_dut.Rabg_of_p(1.);
     EXPECT_NEAR(rotation.roll(), kZeroRoll, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kElevationPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -3. * M_PI / 4., kVeryExact);
     r_hat = elevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareVectors(r_hat, math::Vector3(0.707106781186548, -0.707106781186548, 0.), kVeryExact));
+    EXPECT_TRUE(
+        AssertCompare(CompareVectors(r_hat, math::Vector3(0.707106781186548, -0.707106781186548, 0.), kVeryExact)));
   }
 
   // Checks for a curve with constant non zero superelevation.
@@ -531,31 +544,31 @@ TEST_F(MultilaneArcRoadCurveTest, ReferenceCurveRotation) {
     EXPECT_NEAR(wrap(rotation.pitch()), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), 3. * M_PI / 4., kVeryExact);
     math::Vector3 r_hat = superelevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(
-        CompareVectors(r_hat, math::Vector3(-0.353553390593274, -0.353553390593274, 0.866025403784439), kVeryExact));
+    EXPECT_TRUE(AssertCompare(
+        CompareVectors(r_hat, math::Vector3(-0.353553390593274, -0.353553390593274, 0.866025403784439), kVeryExact)));
 
     rotation = superelevated_dut.Rabg_of_p(0.5);
     EXPECT_NEAR(rotation.roll(), kSuperelevationOffset, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -M_PI, kVeryExact);
     r_hat = superelevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareVectors(r_hat, math::Vector3(0.0, -0.5, 0.866025403784439), kVeryExact));
+    EXPECT_TRUE(AssertCompare(CompareVectors(r_hat, math::Vector3(0.0, -0.5, 0.866025403784439), kVeryExact)));
 
     rotation = superelevated_dut.Rabg_of_p(0.75);
     EXPECT_NEAR(rotation.roll(), kSuperelevationOffset, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -7. * M_PI / 8., kVeryExact);
     r_hat = superelevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(
-        CompareVectors(r_hat, math::Vector3(0.191341716182545, -0.461939766255643, 0.866025403784439), kVeryExact));
+    EXPECT_TRUE(AssertCompare(
+        CompareVectors(r_hat, math::Vector3(0.191341716182545, -0.461939766255643, 0.866025403784439), kVeryExact)));
 
     rotation = superelevated_dut.Rabg_of_p(1.);
     EXPECT_NEAR(rotation.roll(), kSuperelevationOffset, kVeryExact);
     EXPECT_NEAR(wrap(rotation.pitch()), kZeroPitch, kVeryExact);
     EXPECT_NEAR(wrap(rotation.yaw()), -3. * M_PI / 4., kVeryExact);
     r_hat = superelevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(
-        CompareVectors(r_hat, math::Vector3(0.353553390593274, -0.353553390593274, 0.866025403784439), kVeryExact));
+    EXPECT_TRUE(AssertCompare(
+        CompareVectors(r_hat, math::Vector3(0.353553390593274, -0.353553390593274, 0.866025403784439), kVeryExact)));
   }
 }
 

--- a/test/maliput_multilane/multilane_connection_test.cc
+++ b/test/maliput_multilane/multilane_connection_test.cc
@@ -36,20 +36,22 @@
 #include <sstream>
 
 #include <gtest/gtest.h>
+#include <maliput/math/compare.h>
 #include <maliput/math/vector.h>
-#include <maliput/test_utilities/maliput_math_compare.h>
 
+#include "assert_compare.h"
 #include "maliput_multilane/arc_road_curve.h"
 #include "maliput_multilane/cubic_polynomial.h"
 #include "maliput_multilane/line_road_curve.h"
 #include "maliput_multilane/make_road_curve_for_connection.h"
 #include "maliput_multilane_test_utilities/multilane_types_compare.h"
 
+using ::maliput::math::CompareVectors;
+using ::maliput::multilane::test::AssertCompare;
+
 namespace maliput {
 namespace multilane {
 namespace test {
-
-using maliput::math::test::CompareVectors;
 
 // Compares equality within @p tolerance of @p cubic1 and @p cubic2
 // coefficients.
@@ -91,8 +93,6 @@ using maliput::math::test::CompareVectors;
 }  // namespace test
 
 namespace {
-
-using maliput::math::test::CompareVectors;
 
 // EndpointXy checks.
 GTEST_TEST(EndpointXyTest, DefaultConstructor) {
@@ -273,16 +273,17 @@ TEST_F(MultilaneConnectionTest, ArcRoadCurveValidation) {
   EXPECT_NE(dynamic_cast<ArcRoadCurve*>(road_curve.get()), nullptr);
   // Checks that the road curve starts and ends at given endpoints.
   const math::Vector3 flat_origin = road_curve->W_of_prh(0., 0., 0.);
-  EXPECT_TRUE(
+  EXPECT_TRUE(AssertCompare(
       CompareVectors(math::Vector3(flat_dut.start().xy().x(), flat_dut.start().xy().y(), flat_dut.start().z().z()),
-                     flat_origin, kZeroTolerance));
-  EXPECT_TRUE(CompareVectors(math::Vector3(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
-                             flat_origin, kZeroTolerance));
+                     flat_origin, kZeroTolerance)));
+  EXPECT_TRUE(AssertCompare(
+      CompareVectors(math::Vector3(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
+                     flat_origin, kZeroTolerance)));
   const math::Vector3 flat_end = road_curve->W_of_prh(1., 0., 0.);
-  EXPECT_TRUE(CompareVectors(math::Vector3(flat_dut.end().xy().x(), flat_dut.end().xy().y(), flat_dut.end().z().z()),
-                             flat_end, kVeryExact));
-  EXPECT_TRUE(CompareVectors(math::Vector3(kEndEndpoint.xy().x(), kEndEndpoint.xy().y(), kEndEndpoint.z().z()),
-                             flat_end, kVeryExact));
+  EXPECT_TRUE(AssertCompare(CompareVectors(
+      math::Vector3(flat_dut.end().xy().x(), flat_dut.end().xy().y(), flat_dut.end().z().z()), flat_end, kVeryExact)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(
+      math::Vector3(kEndEndpoint.xy().x(), kEndEndpoint.xy().y(), kEndEndpoint.z().z()), flat_end, kVeryExact)));
   // Checks that elevation and superelevation polynomials are correctly built
   // for the trivial case of a flat dut.
   EXPECT_TRUE(test::IsCubicPolynomialClose(road_curve->elevation(), CubicPolynomial(), kZeroTolerance));
@@ -295,18 +296,19 @@ TEST_F(MultilaneConnectionTest, ArcRoadCurveValidation) {
   std::unique_ptr<RoadCurve> complex_road_curve = MakeRoadCurveFor(complex_dut);
   // Checks that the road curve starts and ends at given endpoints.
   const math::Vector3 complex_origin = complex_road_curve->W_of_prh(0., 0., 0.);
-  EXPECT_TRUE(CompareVectors(
+  EXPECT_TRUE(AssertCompare(CompareVectors(
       math::Vector3(complex_dut.start().xy().x(), complex_dut.start().xy().y(), complex_dut.start().z().z()),
-      complex_origin, kZeroTolerance));
-  EXPECT_TRUE(CompareVectors(math::Vector3(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
-                             complex_origin, kZeroTolerance));
+      complex_origin, kZeroTolerance)));
+  EXPECT_TRUE(AssertCompare(
+      CompareVectors(math::Vector3(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
+                     complex_origin, kZeroTolerance)));
   const math::Vector3 complex_end = complex_road_curve->W_of_prh(1., 0., 0.);
-  EXPECT_TRUE(
+  EXPECT_TRUE(AssertCompare(
       CompareVectors(math::Vector3(complex_dut.end().xy().x(), complex_dut.end().xy().y(), complex_dut.end().z().z()),
-                     complex_end, kVeryExact));
-  EXPECT_TRUE(CompareVectors(
+                     complex_end, kVeryExact)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(
       math::Vector3(kEndElevatedEndpoint.xy().x(), kEndElevatedEndpoint.xy().y(), kEndElevatedEndpoint.z().z()),
-      complex_end, kVeryExact));
+      complex_end, kVeryExact)));
   EXPECT_TRUE(test::IsCubicPolynomialClose(
       complex_road_curve->elevation(), CubicPolynomial(0., 0., -0.32476276288217043, 0.549841841921447), kVeryExact));
   EXPECT_TRUE(test::IsCubicPolynomialClose(complex_road_curve->superelevation(),
@@ -326,16 +328,17 @@ TEST_F(MultilaneConnectionTest, LineRoadCurveValidation) {
 
   // Checks that the road curve starts and ends at given endpoints.
   const math::Vector3 flat_origin = road_curve->W_of_prh(0., 0., 0.);
-  EXPECT_TRUE(
+  EXPECT_TRUE(AssertCompare(
       CompareVectors(math::Vector3(flat_dut.start().xy().x(), flat_dut.start().xy().y(), flat_dut.start().z().z()),
-                     flat_origin, kZeroTolerance));
-  EXPECT_TRUE(CompareVectors(math::Vector3(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
-                             flat_origin, kZeroTolerance));
+                     flat_origin, kZeroTolerance)));
+  EXPECT_TRUE(AssertCompare(
+      CompareVectors(math::Vector3(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
+                     flat_origin, kZeroTolerance)));
   const math::Vector3 flat_end = road_curve->W_of_prh(1., 0., 0.);
-  EXPECT_TRUE(CompareVectors(math::Vector3(flat_dut.end().xy().x(), flat_dut.end().xy().y(), flat_dut.end().z().z()),
-                             flat_end, kVeryExact));
-  EXPECT_TRUE(CompareVectors(math::Vector3(kEndEndpoint.xy().x(), kEndEndpoint.xy().y(), kEndEndpoint.z().z()),
-                             flat_end, kVeryExact));
+  EXPECT_TRUE(AssertCompare(CompareVectors(
+      math::Vector3(flat_dut.end().xy().x(), flat_dut.end().xy().y(), flat_dut.end().z().z()), flat_end, kVeryExact)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(
+      math::Vector3(kEndEndpoint.xy().x(), kEndEndpoint.xy().y(), kEndEndpoint.z().z()), flat_end, kVeryExact)));
   // Checks that elevation and superelevation polynomials are correctly built
   // for the trivial case of a flat dut.
   EXPECT_TRUE(test::IsCubicPolynomialClose(road_curve->elevation(), CubicPolynomial(), kZeroTolerance));
@@ -349,18 +352,19 @@ TEST_F(MultilaneConnectionTest, LineRoadCurveValidation) {
 
   // Checks that the road curve starts and ends at given endpoints.
   const math::Vector3 complex_origin = complex_road_curve->W_of_prh(0., 0., 0.);
-  EXPECT_TRUE(CompareVectors(
+  EXPECT_TRUE(AssertCompare(CompareVectors(
       math::Vector3(complex_dut.start().xy().x(), complex_dut.start().xy().y(), complex_dut.start().z().z()),
-      complex_origin, kZeroTolerance));
-  EXPECT_TRUE(CompareVectors(math::Vector3(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
-                             complex_origin, kZeroTolerance));
+      complex_origin, kZeroTolerance)));
+  EXPECT_TRUE(AssertCompare(
+      CompareVectors(math::Vector3(kStartEndpoint.xy().x(), kStartEndpoint.xy().y(), kStartEndpoint.z().z()),
+                     complex_origin, kZeroTolerance)));
   const math::Vector3 complex_end = complex_road_curve->W_of_prh(1., 0., 0.);
-  EXPECT_TRUE(
+  EXPECT_TRUE(AssertCompare(
       CompareVectors(math::Vector3(complex_dut.end().xy().x(), complex_dut.end().xy().y(), complex_dut.end().z().z()),
-                     complex_end, kVeryExact));
-  EXPECT_TRUE(CompareVectors(
+                     complex_end, kVeryExact)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(
       math::Vector3(kEndElevatedEndpoint.xy().x(), kEndElevatedEndpoint.xy().y(), kEndElevatedEndpoint.z().z()),
-      complex_end, kVeryExact));
+      complex_end, kVeryExact)));
   EXPECT_TRUE(test::IsCubicPolynomialClose(complex_road_curve->elevation(),
                                            CubicPolynomial(0., 0., -0.646446609406726, 0.764297739604484), kVeryExact));
   EXPECT_TRUE(test::IsCubicPolynomialClose(complex_road_curve->superelevation(),

--- a/test/maliput_multilane/multilane_line_road_curve_test.cc
+++ b/test/maliput_multilane/multilane_line_road_curve_test.cc
@@ -34,16 +34,20 @@
 #include <utility>
 
 #include <gtest/gtest.h>
+#include <maliput/api/compare.h>
 #include <maliput/api/lane_data.h>
 #include <maliput/common/assertion_error.h>
+#include <maliput/math/compare.h>
 #include <maliput/math/vector.h>
-#include <maliput/test_utilities/maliput_math_compare.h>
+
+#include "assert_compare.h"
 
 namespace maliput {
 namespace multilane {
 namespace {
 
-using maliput::math::test::CompareVectors;
+using maliput::math::CompareVectors;
+using maliput::multilane::test::AssertCompare;
 
 class MultilaneLineRoadCurveTest : public ::testing::Test {
  protected:
@@ -91,13 +95,13 @@ TEST_F(MultilaneLineRoadCurveTest, LineRoadCurve) {
   EXPECT_THROW(p_from_s_at_r0(2. * offset_line_length), maliput::common::assertion_error);
 
   // Check the evaluation of xy at different p values.
-  EXPECT_TRUE(CompareVectors(dut.xy_of_p(0.0), kOrigin, kVeryExact));
-  EXPECT_TRUE(CompareVectors(dut.xy_of_p(0.5), kOrigin + 0.5 * kDirection, kVeryExact));
-  EXPECT_TRUE(CompareVectors(dut.xy_of_p(1.0), kOrigin + kDirection, kVeryExact));
+  EXPECT_TRUE(AssertCompare(CompareVectors(dut.xy_of_p(0.0), kOrigin, kVeryExact)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(dut.xy_of_p(0.5), kOrigin + 0.5 * kDirection, kVeryExact)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(dut.xy_of_p(1.0), kOrigin + kDirection, kVeryExact)));
   // Check the derivative of xy with respect to p at different p values.
-  EXPECT_TRUE(CompareVectors(dut.xy_dot_of_p(0.0), kDirection, kVeryExact));
-  EXPECT_TRUE(CompareVectors(dut.xy_dot_of_p(0.5), kDirection, kVeryExact));
-  EXPECT_TRUE(CompareVectors(dut.xy_dot_of_p(1.0), kDirection, kVeryExact));
+  EXPECT_TRUE(AssertCompare(CompareVectors(dut.xy_dot_of_p(0.0), kDirection, kVeryExact)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(dut.xy_dot_of_p(0.5), kDirection, kVeryExact)));
+  EXPECT_TRUE(AssertCompare(CompareVectors(dut.xy_dot_of_p(1.0), kDirection, kVeryExact)));
   // Check the heading at different p values.
   EXPECT_NEAR(dut.heading_of_p(0.0), kHeading, kVeryExact);
   EXPECT_NEAR(dut.heading_of_p(0.5), kHeading, kVeryExact);
@@ -136,17 +140,22 @@ TEST_F(MultilaneLineRoadCurveTest, IsValidTest) {
 TEST_F(MultilaneLineRoadCurveTest, ToCurveFrameTest) {
   const LineRoadCurve dut(kOrigin, kDirection, zp, zp, kLinearTolerance, kScaleLength, kComputationPolicy);
   // Checks over the base line.
-  EXPECT_TRUE(CompareVectors(dut.ToCurveFrame(math::Vector3(10.0, 10.0, 0.0), kRMin, kRMax, elevation_bounds),
-                             math::Vector3(0.0, 0.0, 0.0), kVeryExact));
-  EXPECT_TRUE(CompareVectors(dut.ToCurveFrame(math::Vector3(20.0, 20.0, 0.0), kRMin, kRMax, elevation_bounds),
-                             math::Vector3(1., 0.0, 0.0), kVeryExact));
-  EXPECT_TRUE(CompareVectors(dut.ToCurveFrame(math::Vector3(15.0, 15.0, 0.0), kRMin, kRMax, elevation_bounds),
-                             math::Vector3(0.5, 0.0, 0.0), kVeryExact));
+  EXPECT_TRUE(
+      AssertCompare(CompareVectors(dut.ToCurveFrame(math::Vector3(10.0, 10.0, 0.0), kRMin, kRMax, elevation_bounds),
+                                   math::Vector3(0.0, 0.0, 0.0), kVeryExact)));
+  EXPECT_TRUE(
+      AssertCompare(CompareVectors(dut.ToCurveFrame(math::Vector3(20.0, 20.0, 0.0), kRMin, kRMax, elevation_bounds),
+                                   math::Vector3(1., 0.0, 0.0), kVeryExact)));
+  EXPECT_TRUE(
+      AssertCompare(CompareVectors(dut.ToCurveFrame(math::Vector3(15.0, 15.0, 0.0), kRMin, kRMax, elevation_bounds),
+                                   math::Vector3(0.5, 0.0, 0.0), kVeryExact)));
   // Check with lateral and vertical deviation.
-  EXPECT_TRUE(CompareVectors(dut.ToCurveFrame(math::Vector3(11.0, 12.0, 5.0), kRMin, kRMax, elevation_bounds),
-                             math::Vector3(0.15, 0.707106781186547, 5.0), kVeryExact));
-  EXPECT_TRUE(CompareVectors(dut.ToCurveFrame(math::Vector3(11.0, 10.0, 7.0), kRMin, kRMax, elevation_bounds),
-                             math::Vector3(0.05, -0.707106781186547, 7.0), kVeryExact));
+  EXPECT_TRUE(
+      AssertCompare(CompareVectors(dut.ToCurveFrame(math::Vector3(11.0, 12.0, 5.0), kRMin, kRMax, elevation_bounds),
+                                   math::Vector3(0.15, 0.707106781186547, 5.0), kVeryExact)));
+  EXPECT_TRUE(
+      AssertCompare(CompareVectors(dut.ToCurveFrame(math::Vector3(11.0, 10.0, 7.0), kRMin, kRMax, elevation_bounds),
+                                   math::Vector3(0.05, -0.707106781186547, 7.0), kVeryExact)));
 }
 
 // Checks that l_max(), p_from_s() and s_from_p() with constant
@@ -209,7 +218,7 @@ TEST_F(MultilaneLineRoadCurveTest, WorldFunction) {
       for (double h : h_vector) {
         const math::Vector3 geo_position =
             kGeoOrigin + p * kDirection.norm() * p_versor + flat_rotation.apply({0., r, h});
-        EXPECT_TRUE(CompareVectors(flat_dut.W_of_prh(p, r, h), geo_position, kVeryExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(flat_dut.W_of_prh(p, r, h), geo_position, kVeryExact)));
       }
     }
   }
@@ -228,7 +237,7 @@ TEST_F(MultilaneLineRoadCurveTest, WorldFunction) {
       for (double h : h_vector) {
         const math::Vector3 geo_position = kGeoOrigin + p * kDirection.norm() * p_versor +
                                            linear_elevation.f_p(p) * z_vector + elevated_rotation.apply({0., r, h});
-        EXPECT_TRUE(CompareVectors(elevated_dut.W_of_prh(p, r, h), geo_position, kVeryExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(elevated_dut.W_of_prh(p, r, h), geo_position, kVeryExact)));
       }
     }
   }
@@ -244,7 +253,7 @@ TEST_F(MultilaneLineRoadCurveTest, WorldFunction) {
       for (double h : h_vector) {
         const math::Vector3 geo_position =
             kGeoOrigin + p * kDirection.norm() * p_versor + superelevated_rotation.apply({0., r, h});
-        EXPECT_TRUE(CompareVectors(superelevated_dut.W_of_prh(p, r, h), geo_position, kVeryExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(superelevated_dut.W_of_prh(p, r, h), geo_position, kVeryExact)));
       }
     }
   }
@@ -281,9 +290,9 @@ TEST_F(MultilaneLineRoadCurveTest, WorldFunctionDerivative) {
         const double g_prime = flat_dut.elevation().f_dot_p(p);
         const math::Vector3 w_prime = flat_dut.W_prime_of_prh(p, r, h, rotation, g_prime);
         const math::Vector3 numeric_w_prime = numeric_w_prime_of_prh(flat_dut, p, r, h);
-        EXPECT_TRUE(CompareVectors(w_prime, numeric_w_prime, kQuiteExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(w_prime, numeric_w_prime, kQuiteExact)));
         const math::Vector3 s_hat = flat_dut.s_hat_of_prh(p, r, h, rotation, g_prime);
-        EXPECT_TRUE(CompareVectors(w_prime.normalized(), s_hat, kVeryExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(w_prime.normalized(), s_hat, kVeryExact)));
       }
     }
   }
@@ -302,9 +311,9 @@ TEST_F(MultilaneLineRoadCurveTest, WorldFunctionDerivative) {
         const double g_prime = elevated_dut.elevation().f_dot_p(p);
         const math::Vector3 w_prime = elevated_dut.W_prime_of_prh(p, r, h, rotation, g_prime);
         const math::Vector3 numeric_w_prime = numeric_w_prime_of_prh(elevated_dut, p, r, h);
-        EXPECT_TRUE(CompareVectors(w_prime, numeric_w_prime, kQuiteExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(w_prime, numeric_w_prime, kQuiteExact)));
         const math::Vector3 s_hat = elevated_dut.s_hat_of_prh(p, r, h, rotation, g_prime);
-        EXPECT_TRUE(CompareVectors(w_prime.normalized(), s_hat, kVeryExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(w_prime.normalized(), s_hat, kVeryExact)));
       }
     }
   }
@@ -321,9 +330,9 @@ TEST_F(MultilaneLineRoadCurveTest, WorldFunctionDerivative) {
         const double g_prime = superelevated_dut.elevation().f_dot_p(p);
         const math::Vector3 w_prime = superelevated_dut.W_prime_of_prh(p, r, h, rotation, g_prime);
         const math::Vector3 numeric_w_prime = numeric_w_prime_of_prh(superelevated_dut, p, r, h);
-        EXPECT_TRUE(CompareVectors(w_prime, numeric_w_prime, kQuiteExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(w_prime, numeric_w_prime, kQuiteExact)));
         const math::Vector3 s_hat = superelevated_dut.s_hat_of_prh(p, r, h, rotation, g_prime);
-        EXPECT_TRUE(CompareVectors(w_prime.normalized(), s_hat, kVeryExact));
+        EXPECT_TRUE(AssertCompare(CompareVectors(w_prime.normalized(), s_hat, kVeryExact)));
       }
     }
   }
@@ -344,7 +353,7 @@ TEST_F(MultilaneLineRoadCurveTest, ReferenceCurveRotation) {
     EXPECT_NEAR(rotation.pitch(), kZeroPitch, kVeryExact);
     EXPECT_NEAR(rotation.yaw(), kHeading, kVeryExact);
     const math::Vector3 r_versor = flat_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareVectors(r_versor, kFlatRDirection.normalized(), kVeryExact));
+    EXPECT_TRUE(AssertCompare(CompareVectors(r_versor, kFlatRDirection.normalized(), kVeryExact)));
   }
 
   // Checks for a linearly elevated curve.
@@ -361,7 +370,7 @@ TEST_F(MultilaneLineRoadCurveTest, ReferenceCurveRotation) {
     EXPECT_NEAR(rotation.pitch(), kLinearPitch, kVeryExact);
     EXPECT_NEAR(rotation.yaw(), kHeading, kVeryExact);
     const math::Vector3 r_versor = elevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareVectors(r_versor, kElevatedRDirection.normalized(), kVeryExact));
+    EXPECT_TRUE(AssertCompare(CompareVectors(r_versor, kElevatedRDirection.normalized(), kVeryExact)));
   }
 
   // Checks for a curve with constant non zero superelevation.
@@ -376,7 +385,7 @@ TEST_F(MultilaneLineRoadCurveTest, ReferenceCurveRotation) {
     EXPECT_NEAR(rotation.pitch(), kZeroPitch, kVeryExact);
     EXPECT_NEAR(rotation.yaw(), kHeading, kVeryExact);
     const math::Vector3 r_versor = superelevated_dut.r_hat_of_Rabg(rotation);
-    EXPECT_TRUE(CompareVectors(r_versor, kSuperelevatedRDirection.normalized(), kVeryExact));
+    EXPECT_TRUE(AssertCompare(CompareVectors(r_versor, kSuperelevatedRDirection.normalized(), kVeryExact)));
   }
 }
 

--- a/test/maliput_multilane/multilane_loader_test.cc
+++ b/test/maliput_multilane/multilane_loader_test.cc
@@ -46,7 +46,6 @@
 #include <maliput/api/lane.h>
 #include <maliput/api/road_geometry.h>
 #include <maliput/api/segment.h>
-#include <maliput/test_utilities/maliput_types_compare.h>
 
 #include "maliput_multilane/builder.h"
 #include "maliput_multilane/connection.h"

--- a/test/maliput_multilane/multilane_road_geometry_test.cc
+++ b/test/maliput_multilane/multilane_road_geometry_test.cc
@@ -37,9 +37,10 @@
 #include <utility>
 
 #include <gtest/gtest.h>
+#include <maliput/api/compare.h>
 #include <maliput/common/maliput_abort.h>
-#include <maliput/test_utilities/maliput_types_compare.h>
 
+#include "assert_compare.h"
 #include "maliput_multilane/builder.h"
 
 namespace maliput {
@@ -50,6 +51,7 @@ using api::HBounds;
 using api::RBounds;
 using multilane::ArcOffset;
 using Which = api::LaneEnd::Which;
+using test::AssertCompare;
 
 const double kVeryExact{1e-11};
 const double kWidth{2.};   // Half lane width, used to feed the BuilderFactory.
@@ -136,13 +138,13 @@ TEST_F(MultilaneLanesQueriesTest, DoToRoadPosition) {
   api::RoadPositionResult result = rg_->ToRoadPosition(inertial_pos);
 
   // Expect to locate the point centered within lane1 (straight segment).
-  EXPECT_TRUE(api::test::IsLanePositionClose(
-      result.road_position.pos, api::LanePosition(kLength / 2. /* s */, 0. /* r */, 0. /* h */), kVeryExact));
+  EXPECT_TRUE(AssertCompare(api::IsLanePositionClose(
+      result.road_position.pos, api::LanePosition(kLength / 2. /* s */, 0. /* r */, 0. /* h */), kVeryExact)));
   EXPECT_EQ(result.road_position.lane->id(), api::LaneId("l:lane1_0"));
   EXPECT_EQ(result.distance, 0.);
-  EXPECT_TRUE(api::test::IsInertialPositionClose(
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(
       result.nearest_position, api::InertialPosition(inertial_pos.x(), inertial_pos.y(), inertial_pos.z()),
-      kVeryExact));
+      kVeryExact)));
 
   // Place a point halfway to the end of lane1, just to the outside (left side)
   // of the lane bounds.
@@ -151,51 +153,52 @@ TEST_F(MultilaneLanesQueriesTest, DoToRoadPosition) {
 
   // Expect to locate the point just outside (to the left) of lane1, by an
   // amount kWidth.
-  EXPECT_TRUE(api::test::IsLanePositionClose(
-      result.road_position.pos, api::LanePosition(kLength / 2. /* s */, kWidth /* r */, 0. /* h */), kVeryExact));
+  EXPECT_TRUE(AssertCompare(api::IsLanePositionClose(
+      result.road_position.pos, api::LanePosition(kLength / 2. /* s */, kWidth /* r */, 0. /* h */), kVeryExact)));
   EXPECT_EQ(result.road_position.lane->id(), api::LaneId("l:lane1_0"));
   EXPECT_EQ(result.distance, kWidth);
-  EXPECT_TRUE(api::test::IsInertialPositionClose(
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(
       result.nearest_position, api::InertialPosition(inertial_pos.x() - kWidth, inertial_pos.y(), inertial_pos.z()),
-      kVeryExact));
+      kVeryExact)));
 
   // Place a point at the middle of lane3a (straight segment).
   inertial_pos = api::InertialPosition(2. * kArcRadius + kLength / 2., -2. * kArcRadius - kLength, 0.);
   result = rg_->ToRoadPosition(inertial_pos);
 
   // Expect to locate the point centered within lane3a.
-  EXPECT_TRUE(api::test::IsLanePositionClose(
-      result.road_position.pos, api::LanePosition(kLength / 2. /* s */, 0. /* r */, 0. /* h */), kVeryExact));
+  EXPECT_TRUE(AssertCompare(api::IsLanePositionClose(
+      result.road_position.pos, api::LanePosition(kLength / 2. /* s */, 0. /* r */, 0. /* h */), kVeryExact)));
   EXPECT_EQ(result.road_position.lane->id(), api::LaneId("l:lane3a_0"));
   EXPECT_EQ(result.distance, 0.);
-  EXPECT_TRUE(api::test::IsInertialPositionClose(
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(
       result.nearest_position, api::InertialPosition(inertial_pos.x(), inertial_pos.y(), inertial_pos.z()),
-      kVeryExact));
+      kVeryExact)));
 
   // Place a point high above the middle of lane3a (straight segment).
   inertial_pos = api::InertialPosition(2. * kArcRadius + kLength / 2., -2. * kArcRadius - kLength, 50.);
   result = rg_->ToRoadPosition(inertial_pos);
 
   // Expect to locate the point centered above lane3a.
-  EXPECT_TRUE(api::test::IsLanePositionClose(
-      result.road_position.pos, api::LanePosition(kLength / 2. /* s */, 0. /* r */, kHeight /* h */), kVeryExact));
+  EXPECT_TRUE(AssertCompare(api::IsLanePositionClose(
+      result.road_position.pos, api::LanePosition(kLength / 2. /* s */, 0. /* r */, kHeight /* h */), kVeryExact)));
   EXPECT_EQ(result.road_position.lane->id(), api::LaneId("l:lane3a_0"));
   EXPECT_EQ(result.distance, 50. - kHeight);
-  EXPECT_TRUE(api::test::IsInertialPositionClose(
-      result.nearest_position, api::InertialPosition(inertial_pos.x(), inertial_pos.y(), kHeight), kVeryExact));
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(
+      result.nearest_position, api::InertialPosition(inertial_pos.x(), inertial_pos.y(), kHeight), kVeryExact)));
 
   // Place a point at the end of lane3b (arc segment).
   inertial_pos = api::InertialPosition(2. * kArcRadius + kLength, -kArcRadius - kLength, 0.);
   result = rg_->ToRoadPosition(inertial_pos);
 
   // Expect to locate the point at the end of lane3b.
-  EXPECT_TRUE(api::test::IsLanePositionClose(
-      result.road_position.pos, api::LanePosition(kArcRadius * M_PI / 2. /* s */, 0. /* r */, 0. /* h */), kVeryExact));
+  EXPECT_TRUE(AssertCompare(
+      api::IsLanePositionClose(result.road_position.pos,
+                               api::LanePosition(kArcRadius * M_PI / 2. /* s */, 0. /* r */, 0. /* h */), kVeryExact)));
   EXPECT_EQ(result.road_position.lane->id(), api::LaneId("l:lane3b_0"));
   EXPECT_EQ(result.distance, 0.);
-  EXPECT_TRUE(api::test::IsInertialPositionClose(
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(
       result.nearest_position, api::InertialPosition(inertial_pos.x(), inertial_pos.y(), inertial_pos.z()),
-      kVeryExact));
+      kVeryExact)));
 
   // Supply a hint with a position at the start of lane3c to try and determine
   // the RoadPosition for a point at the end of lane3b.
@@ -216,9 +219,9 @@ TEST_F(MultilaneLanesQueriesTest, DoToRoadPosition) {
   // within lane lane3b.
   EXPECT_EQ(result.road_position.lane->id(), api::LaneId("l:lane3b_0"));
   EXPECT_EQ(result.distance, 0.);  // inertial_pos is inside lane3b.
-  EXPECT_TRUE(api::test::IsInertialPositionClose(
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(
       result.nearest_position, api::InertialPosition(inertial_pos.x(), inertial_pos.y(), inertial_pos.z()),
-      kVeryExact));
+      kVeryExact)));
 }
 
 TEST_F(MultilaneLanesQueriesTest, DoToFindRoadPositions) {
@@ -232,13 +235,13 @@ TEST_F(MultilaneLanesQueriesTest, DoToFindRoadPositions) {
   api::RoadPositionResult result = results[0];
 
   // Expect to locate the point centered within lane1 (straight segment).
-  EXPECT_TRUE(api::test::IsLanePositionClose(
-      result.road_position.pos, api::LanePosition(kLength / 2. /* s */, 0. /* r */, 0. /* h */), kVeryExact));
+  EXPECT_TRUE(AssertCompare(api::IsLanePositionClose(
+      result.road_position.pos, api::LanePosition(kLength / 2. /* s */, 0. /* r */, 0. /* h */), kVeryExact)));
   EXPECT_EQ(result.road_position.lane->id(), api::LaneId("l:lane1_0"));
   EXPECT_EQ(result.distance, 0.);
-  EXPECT_TRUE(api::test::IsInertialPositionClose(
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(
       result.nearest_position, api::InertialPosition(inertial_pos.x(), inertial_pos.y(), inertial_pos.z()),
-      kVeryExact));
+      kVeryExact)));
 
   // Place the point at the end of lane1. Lane1 and lane2 should be found.
   inertial_pos = {kArcRadius, -kArcRadius - kLength, 0.};
@@ -259,13 +262,13 @@ TEST_F(MultilaneLanesQueriesTest, DoToFindRoadPositions) {
 
   // Expect to locate the point at the end of lane1.
   const api::InertialPosition inertial_pos_lane_1{kArcRadius, -kArcRadius - kLength, 0.};
-  EXPECT_TRUE(api::test::IsLanePositionClose(result.road_position.pos,
-                                             api::LanePosition(kLength /* s */, 0. /* r */, 0. /* h */), kVeryExact));
+  EXPECT_TRUE(AssertCompare(api::IsLanePositionClose(
+      result.road_position.pos, api::LanePosition(kLength /* s */, 0. /* r */, 0. /* h */), kVeryExact)));
   EXPECT_EQ(result.road_position.lane->id(), api::LaneId("l:lane1_0"));
   EXPECT_EQ(result.distance, 0.);
-  EXPECT_TRUE(api::test::IsInertialPositionClose(
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(
       result.nearest_position,
-      api::InertialPosition(inertial_pos_lane_1.x(), inertial_pos_lane_1.y(), inertial_pos_lane_1.z()), kVeryExact));
+      api::InertialPosition(inertial_pos_lane_1.x(), inertial_pos_lane_1.y(), inertial_pos_lane_1.z()), kVeryExact)));
 
   // Checking l:lane2_0 result.
   auto lane_2_0_itr = find_lane_in_results(api::LaneId("l:lane2_0"), results);
@@ -274,13 +277,13 @@ TEST_F(MultilaneLanesQueriesTest, DoToFindRoadPositions) {
 
   // Expect to locate the point at the end of lane1.
   const api::InertialPosition inertial_pos_lane_2{kArcRadius, -kArcRadius - kLength, 0.};
-  EXPECT_TRUE(api::test::IsLanePositionClose(result.road_position.pos,
-                                             api::LanePosition(0. /* s */, 0. /* r */, 0. /* h */), kVeryExact));
+  EXPECT_TRUE(AssertCompare(api::IsLanePositionClose(
+      result.road_position.pos, api::LanePosition(0. /* s */, 0. /* r */, 0. /* h */), kVeryExact)));
   EXPECT_EQ(result.road_position.lane->id(), api::LaneId("l:lane2_0"));
   EXPECT_EQ(result.distance, 0.);
-  EXPECT_TRUE(api::test::IsInertialPositionClose(
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(
       result.nearest_position,
-      api::InertialPosition(inertial_pos_lane_2.x(), inertial_pos_lane_2.y(), inertial_pos_lane_2.z()), kVeryExact));
+      api::InertialPosition(inertial_pos_lane_2.x(), inertial_pos_lane_2.y(), inertial_pos_lane_2.z()), kVeryExact)));
 }
 
 GTEST_TEST(MultilaneLanesTest, HintWithDisconnectedLanes) {
@@ -424,10 +427,10 @@ GTEST_TEST(MultilaneLanesTest, MultipleLineLaneSegmentWithoutHint) {
   for (const auto truth_value : truth_vector) {
     EXPECT_NO_THROW(result = rg->ToRoadPosition(std::get<0>(truth_value)));
     EXPECT_EQ(result.road_position.lane->id(), std::get<1>(truth_value).lane->id());
-    EXPECT_TRUE(
-        api::test::IsLanePositionClose(result.road_position.pos, std::get<1>(truth_value).pos, kLinearTolerance));
-    EXPECT_TRUE(
-        api::test::IsInertialPositionClose(result.nearest_position, std::get<2>(truth_value), kLinearTolerance));
+    EXPECT_TRUE(AssertCompare(
+        api::IsLanePositionClose(result.road_position.pos, std::get<1>(truth_value).pos, kLinearTolerance)));
+    EXPECT_TRUE(AssertCompare(
+        api::IsInertialPositionClose(result.nearest_position, std::get<2>(truth_value), kLinearTolerance)));
     EXPECT_NEAR(result.distance, std::get<4>(truth_value), kLinearTolerance);
   }
 
@@ -435,10 +438,10 @@ GTEST_TEST(MultilaneLanesTest, MultipleLineLaneSegmentWithoutHint) {
   for (const auto truth_value : truth_vector) {
     EXPECT_NO_THROW(result = rg->ToRoadPosition(std::get<0>(truth_value), std::get<3>(truth_value)));
     EXPECT_EQ(result.road_position.lane->id(), std::get<1>(truth_value).lane->id());
-    EXPECT_TRUE(
-        api::test::IsLanePositionClose(result.road_position.pos, std::get<1>(truth_value).pos, kLinearTolerance));
-    EXPECT_TRUE(
-        api::test::IsInertialPositionClose(result.nearest_position, std::get<2>(truth_value), kLinearTolerance));
+    EXPECT_TRUE(AssertCompare(
+        api::IsLanePositionClose(result.road_position.pos, std::get<1>(truth_value).pos, kLinearTolerance)));
+    EXPECT_TRUE(AssertCompare(
+        api::IsInertialPositionClose(result.nearest_position, std::get<2>(truth_value), kLinearTolerance)));
     EXPECT_NEAR(result.distance, std::get<4>(truth_value), kLinearTolerance);
   }
 }
@@ -505,9 +508,9 @@ GTEST_TEST(MultilaneLanesTest, OverlappingLaneBounds) {
   const api::InertialPosition kAPoint(0., 0., 0.);
   EXPECT_NO_THROW(result = rg->ToRoadPosition(kAPoint));
   EXPECT_NE(result.road_position.lane, nullptr);
-  EXPECT_TRUE(
-      api::test::IsLanePositionClose(result.road_position.pos, api::LanePosition(0., 0., 0.), kLinearTolerance));
-  EXPECT_TRUE(api::test::IsInertialPositionClose(result.nearest_position, kAPoint, kLinearTolerance));
+  EXPECT_TRUE(AssertCompare(
+      api::IsLanePositionClose(result.road_position.pos, api::LanePosition(0., 0., 0.), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(result.nearest_position, kAPoint, kLinearTolerance)));
   EXPECT_NEAR(result.distance, 0., kLinearTolerance);
 
   // Using the same InertialPosition, but with a line-hint, we should get the
@@ -515,18 +518,18 @@ GTEST_TEST(MultilaneLanesTest, OverlappingLaneBounds) {
   const api::RoadPosition kStartLineLane{line_lane, api::LanePosition(0., 0., 0.)};
   EXPECT_NO_THROW(result = rg->ToRoadPosition(kAPoint, kStartLineLane));
   EXPECT_EQ(result.road_position.lane->id(), line_lane->id());
-  EXPECT_TRUE(
-      api::test::IsLanePositionClose(result.road_position.pos, api::LanePosition(0., 0., 0.), kLinearTolerance));
-  EXPECT_TRUE(api::test::IsInertialPositionClose(result.nearest_position, kAPoint, kLinearTolerance));
+  EXPECT_TRUE(AssertCompare(
+      api::IsLanePositionClose(result.road_position.pos, api::LanePosition(0., 0., 0.), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(result.nearest_position, kAPoint, kLinearTolerance)));
   EXPECT_NEAR(result.distance, 0., kLinearTolerance);
 
   // Same as before, but with a hint on the arc-segment.
   const api::RoadPosition kStartArcLane{arc_lane, api::LanePosition(0., 0., 0.)};
   EXPECT_NO_THROW(result = rg->ToRoadPosition(kAPoint, kStartArcLane));
   EXPECT_EQ(result.road_position.lane->id(), arc_lane->id());
-  EXPECT_TRUE(
-      api::test::IsLanePositionClose(result.road_position.pos, api::LanePosition(0., 0., 0.), kLinearTolerance));
-  EXPECT_TRUE(api::test::IsInertialPositionClose(result.nearest_position, kAPoint, kLinearTolerance));
+  EXPECT_TRUE(AssertCompare(
+      api::IsLanePositionClose(result.road_position.pos, api::LanePosition(0., 0., 0.), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(result.nearest_position, kAPoint, kLinearTolerance)));
   EXPECT_NEAR(result.distance, 0., kLinearTolerance);
 
   // Tests a InertialPosition in between line and arc lane curves. It is closer to
@@ -540,9 +543,9 @@ GTEST_TEST(MultilaneLanesTest, OverlappingLaneBounds) {
   const api::InertialPosition kBPoint(kX, kROffset, 0.);
   EXPECT_NO_THROW(result = rg->ToRoadPosition(kBPoint));
   EXPECT_EQ(result.road_position.lane->id(), line_lane->id());
-  EXPECT_TRUE(
-      api::test::IsLanePositionClose(result.road_position.pos, api::LanePosition(kX, kROffset, 0.), kLinearTolerance));
-  EXPECT_TRUE(api::test::IsInertialPositionClose(result.nearest_position, kBPoint, kLinearTolerance));
+  EXPECT_TRUE(AssertCompare(
+      api::IsLanePositionClose(result.road_position.pos, api::LanePosition(kX, kROffset, 0.), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(result.nearest_position, kBPoint, kLinearTolerance)));
   EXPECT_NEAR(result.distance, 0., kLinearTolerance);
 
   // Tests a InertialPosition in between line and arc lane curves. It is closer to
@@ -555,9 +558,9 @@ GTEST_TEST(MultilaneLanesTest, OverlappingLaneBounds) {
   const api::InertialPosition kCPoint(kX, kCY, 0.);
   EXPECT_NO_THROW(result = rg->ToRoadPosition(kCPoint));
   EXPECT_EQ(result.road_position.lane->id(), arc_lane->id());
-  EXPECT_TRUE(api::test::IsLanePositionClose(result.road_position.pos,
-                                             api::LanePosition(kRadius * kCTheta, -kROffset, 0.), kLinearTolerance));
-  EXPECT_TRUE(api::test::IsInertialPositionClose(result.nearest_position, kCPoint, kLinearTolerance));
+  EXPECT_TRUE(AssertCompare(api::IsLanePositionClose(
+      result.road_position.pos, api::LanePosition(kRadius * kCTheta, -kROffset, 0.), kLinearTolerance)));
+  EXPECT_TRUE(AssertCompare(api::IsInertialPositionClose(result.nearest_position, kCPoint, kLinearTolerance)));
   EXPECT_NEAR(result.distance, 0., kLinearTolerance);
 }
 

--- a/test/maliput_multilane/multilane_segments_test.cc
+++ b/test/maliput_multilane/multilane_segments_test.cc
@@ -32,9 +32,10 @@
 /* clang-format on */
 
 #include <gtest/gtest.h>
+#include <maliput/api/compare.h>
 #include <maliput/math/vector.h>
-#include <maliput/test_utilities/maliput_types_compare.h>
 
+#include "assert_compare.h"
 #include "maliput_multilane/arc_road_curve.h"
 #include "maliput_multilane/junction.h"
 #include "maliput_multilane/lane.h"
@@ -45,6 +46,8 @@
 namespace maliput {
 namespace multilane {
 namespace {
+
+using test::AssertCompare;
 
 const double kLinearTolerance = 1e-6;
 const double kAngularTolerance = 1e-6;
@@ -82,12 +85,13 @@ GTEST_TEST(MultilaneSegmentsTest, MultipleLanes) {
 
   EXPECT_EQ(rg.CheckInvariants(), std::vector<std::string>());
 
-  EXPECT_TRUE(api::test::IsRBoundsClose(l0->lane_bounds(0.), {-8., kHalfLaneWidth}, kZeroTolerance));
-  EXPECT_TRUE(api::test::IsRBoundsClose(l0->segment_bounds(0.), {-8., 32.}, kZeroTolerance));
-  EXPECT_TRUE(api::test::IsRBoundsClose(l1->lane_bounds(0.), {-kHalfLaneWidth, kHalfLaneWidth}, kZeroTolerance));
-  EXPECT_TRUE(api::test::IsRBoundsClose(l1->segment_bounds(0.), {-23., 17.}, kZeroTolerance));
-  EXPECT_TRUE(api::test::IsRBoundsClose(l2->lane_bounds(0.), {-kHalfLaneWidth, 2.}, kZeroTolerance));
-  EXPECT_TRUE(api::test::IsRBoundsClose(l2->segment_bounds(0.), {-38., 2.}, kZeroTolerance));
+  EXPECT_TRUE(AssertCompare(api::IsRBoundsClose(l0->lane_bounds(0.), {-8., kHalfLaneWidth}, kZeroTolerance)));
+  EXPECT_TRUE(AssertCompare(api::IsRBoundsClose(l0->segment_bounds(0.), {-8., 32.}, kZeroTolerance)));
+  EXPECT_TRUE(
+      AssertCompare(api::IsRBoundsClose(l1->lane_bounds(0.), {-kHalfLaneWidth, kHalfLaneWidth}, kZeroTolerance)));
+  EXPECT_TRUE(AssertCompare(api::IsRBoundsClose(l1->segment_bounds(0.), {-23., 17.}, kZeroTolerance)));
+  EXPECT_TRUE(AssertCompare(api::IsRBoundsClose(l2->lane_bounds(0.), {-kHalfLaneWidth, 2.}, kZeroTolerance)));
+  EXPECT_TRUE(AssertCompare(api::IsRBoundsClose(l2->segment_bounds(0.), {-38., 2.}, kZeroTolerance)));
 }
 
 }  // namespace


### PR DESCRIPTION
# 🎉 New feature
:exclamation:  Goes on top https://github.com/maliput/maliput/pull/600
Part of https://github.com/maliput/maliput/issues/602

## Summary
 - Uses compare methods instead.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

action-ros-ci-repos-override: https://gist.githubusercontent.com/francocipollone/b4f12ba16f95b45495362ae94202e810/raw/9db4de603d3df5286ba77d7184ccc2301710bbd2/maliput_multilane.repos